### PR TITLE
align OIDC username attribute name lookup

### DIFF
--- a/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
+++ b/hawkbit-autoconfigure/src/main/java/org/eclipse/hawkbit/autoconfigure/security/OidcUserManagementAutoConfiguration.java
@@ -162,8 +162,8 @@ class JwtAuthoritiesOidcUserService extends OidcUserService {
 
         final String userNameAttributeName = clientRegistration.getProviderDetails().getUserInfoEndpoint()
                 .getUserNameAttributeName();
-        OidcUser oidcUser;
-        if (StringUtils.hasText(userNameAttributeName)) {
+        final OidcUser oidcUser;
+        if (StringUtils.hasText(userNameAttributeName) && user.getClaims().containsKey(userNameAttributeName)) {
             oidcUser = new DefaultOidcUser(authorities, userRequest.getIdToken(), user.getUserInfo(),
                     userNameAttributeName);
         } else {
@@ -334,9 +334,18 @@ class OidcBearerTokenAuthenticationFilter implements UserAuthenticationFilter, F
                 return;
             }
 
-            final DefaultOidcUser user = new DefaultOidcUser(authorities, idToken, userInfo);
+            final String userNameAttributeName = clientRegistration.getProviderDetails().getUserInfoEndpoint()
+                    .getUserNameAttributeName();
 
-            final OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(user, authorities,
+            final DefaultOidcUser oidcUser;            
+            if (StringUtils.hasText(userNameAttributeName) && jwt.getClaims().containsKey(userNameAttributeName)) {
+                oidcUser = new DefaultOidcUser(authorities, idToken, userInfo, userNameAttributeName);
+
+            } else {
+                oidcUser = new DefaultOidcUser(authorities, idToken, userInfo);
+            }
+
+            final OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(oidcUser, authorities,
                     clientRegistration.getRegistrationId());
 
             oAuth2AuthenticationToken.setDetails(new TenantAwareAuthenticationDetails(defaultTenant, false));

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SpringSecurityAuditorAware.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/security/SpringSecurityAuditorAware.java
@@ -40,7 +40,7 @@ public class SpringSecurityAuditorAware implements AuditorAware<String> {
             return ((UserDetails) authentication.getPrincipal()).getUsername();
         }
         if (authentication.getPrincipal() instanceof OidcUser) {
-            return ((OidcUser) authentication.getPrincipal()).getPreferredUsername();
+            return ((OidcUser) authentication.getPrincipal()).getName();
         }
         return authentication.getPrincipal().toString();
     }


### PR DESCRIPTION
Signed-off-by: Martin Daur <mdaur@gmx.net>
This fix aligns the behaviour hence OIDC username attribute name lookup at these two places:
- OidcBearerTokenAuthenticationFilter/doFilter
- JwtAuthoritiesOidcUserService/loadUser

Additionally, this fix checks the existence of the claim which is set by the Spring user-name-attribute property. Doing so allows OIDC scenarios in which the userNameAttributeName might not be available in case of different OAuth flows. E.g. in Azure AD preferredUsername is available for OAuth 2.0 auth code grant and OAuth 2.0 device code flow but it is not available for Oauth 2.0 client credentials grants with shared secrets or certificates.

To align with the Spring user-name-attribute property (spring.security.oauth2.client.provider) it makes sense to return the name of the OidcUser and not hardcoded the preferredUser (see SpringSecurityAuditorAware).

For backward compatibly you may configure the provider as follows (including the benefit to have a fallback to the sub as the username if there is no such claim):
spring.security.oauth2.client.provider.azure.user-name-attribute=preferred_username

Without these adjustments you may end up with "NULL" usernames at various places (e.g. Created by, Last modified by), which also breaks the UI.