### PR TITLE
Fix handling of artifact range requests

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/model/DbArtifact.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/artifact/repository/model/DbArtifact.java
@@ -43,4 +43,13 @@ public interface DbArtifact {
      * @return {@link InputStream} to read from artifact.
      */
     InputStream getFileInputStream();
+
+    /**
+     * Creates an {@link InputStream} on a single range of this artifact.
+     * The caller has to take care of closing the stream.
+     * Repeatable calls open a new {@link InputStream}.
+     *
+     * @return {@link InputStream} to read from artifact.
+     */
+    InputStream getFileInputStream(long start, long end);
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/EncryptionAwareDbArtifact.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/EncryptionAwareDbArtifact.java
@@ -63,4 +63,9 @@ public class EncryptionAwareDbArtifact implements DbArtifact {
     public InputStream getFileInputStream() {
         return decryptionFunction.apply(encryptedDbArtifact.getFileInputStream());
     }
+
+    @Override
+    public InputStream getFileInputStream(long start, long end) {
+        return decryptionFunction.apply(encryptedDbArtifact.getFileInputStream(start, end));
+    }
 }

--- a/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/util/FileStreamingUtil.java
@@ -285,8 +285,8 @@ public final class FileStreamingUtil {
             final ServletOutputStream to = response.getOutputStream();
 
             for (final ByteRange r : ranges) {
-                try (final InputStream from = artifact.getFileInputStream()) {
 
+                try (final InputStream from = artifact.getFileInputStream(r.getStart(), r.getEnd())) {
                     // Add multipart boundary and header fields for every range.
                     to.println();
                     to.println("--" + ByteRange.MULTIPART_BOUNDARY);
@@ -316,7 +316,7 @@ public final class FileStreamingUtil {
         response.setContentLengthLong(r.getLength());
         response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
 
-        try (final InputStream from = artifact.getFileInputStream()) {
+        try (final InputStream from = artifact.getFileInputStream(r.getStart(), r.getEnd())) {
             final ServletOutputStream to = response.getOutputStream();
             copyStreams(from, to, progressListener, r.getStart(), r.getLength(), filename);
         } catch (final IOException e) {
@@ -339,8 +339,6 @@ public final class FileStreamingUtil {
         final byte[] buf = new byte[BUFFER_SIZE];
         long total = 0;
         int progressPercent = 1;
-
-        ByteStreams.skipFully(from, start);
 
         long toRead = length;
         boolean toContinue = true;

--- a/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/util/FileStreamingUtilTest.java
+++ b/hawkbit-rest/hawkbit-rest-core/src/test/java/org/eclipse/hawkbit/rest/util/FileStreamingUtilTest.java
@@ -69,6 +69,11 @@ class FileStreamingUtilTest {
         public InputStream getFileInputStream() {
             return new ByteArrayInputStream(CONTENT_BYTES);
         }
+
+        @Override
+        public InputStream getFileInputStream(long start, long end) {
+            return new ByteArrayInputStream(CONTENT_BYTES, (int) start, (int) (end - start + 1));
+        }
     };
 
     @Test


### PR DESCRIPTION
Artifact range requests in HawkBit were impossible to do efficiently, as the underlying mechanism had no choice but to read the start byte and discard content both before and after.

To address this situation, we need to introduce a new method to DbArtifact: getFileInputStream(long, long), which maps to the semantics of a range request.

The next step is to adjust FileStreamingUtil to use it for both simple range and multi-part requests.