### PR TITLE
Fix ddi_api.md to clarify how to accept a cancellation

### DIFF
--- a/site/content/apis/ddi_api.md
+++ b/site/content/apis/ddi_api.md
@@ -31,6 +31,7 @@ PROCEEDING                  | This can be used by the target to inform that it i
 SCHEDULED                   | This can be used by the target to inform that it scheduled on the action.                                                                                                                                                                | RUNNING
 RESUMED                     | This can be used by the target to inform that it continued to work on the action.                                                                                                                                                        | RUNNING
 
+See this [issue](https://github.com/eclipse/hawkbit/issues/952) for additional information, concerning the cancellation of updates. To finally accept a cancellation, you must send a "closed" status.exection type. 
 ## DDI APIs
 
 <iframe style="padding-top: 20px;" width="100%" height="900px" frameborder="0" src="../../rest-api/ddi.html"></iframe>


### PR DESCRIPTION
As laid out in this issue https://github.com/eclipse/hawkbit/issues/952, the documentation does not reflect the real behaviour of hawkBit concerning cancellation acceptance (Or there is a bug).
Until the documentation is updated by a maintainer with deep knowledge of the system or the bug is fixed, this clarification in the documentation will help people to understand that they can't send a "canceled" update status to hawkBit to accept a cancellation as it is stated. This will save them a lot of time of finding the linked issue and understand the problem outlined there.