### PR TITLE
Fix concurrent starting the next group

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DeploymentManagement.java
@@ -360,20 +360,6 @@ public interface DeploymentManagement {
     Page<String> findMessagesByActionStatusId(@NotNull Pageable pageable, long actionStatusId);
 
     /**
-     * Counts all messages for an {@link ActionStatus}.
-     * <p/>
-     * No access control applied.
-     *
-     * @deprecated Used by UI only. With future removal of UI it could be removed.
-     * @param actionStatusId
-     *            the id of {@link ActionStatus} to count the messages from
-     * @return count of messages by a specific {@link ActionStatus} id
-     */
-    @Deprecated(forRemoval = true)
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    long countMessagesByActionStatusId(long actionStatusId);
-
-    /**
      * Get the {@link Action} entity for given actionId with all lazy attributes
      * (i.e. distributionSet, target, target.assignedDs).
      *
@@ -498,7 +484,7 @@ public interface DeploymentManagement {
      * @return the amount of started actions
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
-    long startScheduledActionsByRolloutGroupParent(long rolloutId, long distributionSetId, Long rolloutGroupParentId);
+    void startScheduledActionsByRolloutGroupParent(long rolloutId, long distributionSetId, Long rolloutGroupParentId);
 
     /**
      * Handles the target assignments. Shall be part of same group

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/RolloutGroupRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/RolloutGroupRepository.java
@@ -121,7 +121,7 @@ public interface RolloutGroupRepository
     @Modifying
     @Transactional
     @Query("UPDATE JpaRolloutGroup g SET g.status = :status WHERE g.parent = :parent")
-    void setStatusForCildren(@Param("status") RolloutGroupStatus status, @Param("parent") RolloutGroup parent);
+    void setStatusForChildren(@Param("status") RolloutGroupStatus status, @Param("parent") RolloutGroup parent);
 
     /**
      * Retrieves all {@link RolloutGroup} for a specific rollout and status not

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/StartNextGroupRolloutGroupSuccessAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/StartNextGroupRolloutGroupSuccessAction.java
@@ -9,12 +9,9 @@
  */
 package org.eclipse.hawkbit.repository.jpa.rollout.condition;
 
-import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.hawkbit.repository.DeploymentManagement;
 import org.eclipse.hawkbit.repository.jpa.repository.RolloutGroupRepository;
-import org.eclipse.hawkbit.repository.jpa.model.JpaRolloutGroup;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupStatus;
@@ -27,13 +24,12 @@ import org.eclipse.hawkbit.security.SystemSecurityContext;
 public class StartNextGroupRolloutGroupSuccessAction implements RolloutGroupActionEvaluator<RolloutGroup.RolloutGroupSuccessAction> {
 
     private final RolloutGroupRepository rolloutGroupRepository;
-
     private final DeploymentManagement deploymentManagement;
-
     private final SystemSecurityContext systemSecurityContext;
 
-    public StartNextGroupRolloutGroupSuccessAction(final RolloutGroupRepository rolloutGroupRepository,
-            final DeploymentManagement deploymentManagement, final SystemSecurityContext systemSecurityContext) {
+    public StartNextGroupRolloutGroupSuccessAction(
+            final RolloutGroupRepository rolloutGroupRepository, final DeploymentManagement deploymentManagement,
+            final SystemSecurityContext systemSecurityContext) {
         this.rolloutGroupRepository = rolloutGroupRepository;
         this.deploymentManagement = deploymentManagement;
         this.systemSecurityContext = systemSecurityContext;
@@ -44,45 +40,25 @@ public class StartNextGroupRolloutGroupSuccessAction implements RolloutGroupActi
         return RolloutGroup.RolloutGroupSuccessAction.NEXTGROUP;
     }
 
+    // Note - the exec could be called by JpaRolloutsExecutor and buy JpaRolloutsManagement#triggerNextGroup
+    // this means it cold be called by concurrently.
     @Override
     public void exec(final Rollout rollout, final RolloutGroup rolloutGroup) {
         systemSecurityContext.runAsSystem(() -> {
-            startNextGroup(rollout, rolloutGroup);
+            // retrieve all actions according to the parent group of the finished rolloutGroup,
+            // so retrieve all child-group actions which need to be started.
+            deploymentManagement.startScheduledActionsByRolloutGroupParent(
+                    rollout.getId(), rollout.getDistributionSet().getId(), rolloutGroup.getId());
+            log.debug("Next actions started for rollout {} and parent group {}", rollout, rolloutGroup);
+            if (!rolloutGroupRepository
+                    .findByParentIdAndStatus(rolloutGroup.getId(), RolloutGroupStatus.SCHEDULED).isEmpty()) {
+                // get next scheduled group and set them in state running
+                // there could be a case that the next group is empty (e.g. targets has been deleted after the group has been scheduled)
+                // but then, on the next run it will be finished and next will be started.
+                rolloutGroupRepository.setStatusForChildren(RolloutGroupStatus.RUNNING, rolloutGroup);
+                log.debug("Next group set to RUNNING for rollout {} and parent group {}", rollout, rolloutGroup);
+            }
             return null;
         });
-    }
-
-    private void startNextGroup(final Rollout rollout, final RolloutGroup rolloutGroup) {
-        // retrieve all actions according to the parent group of the finished
-        // rolloutGroup, so retrieve all child-group actions which need to be
-        // started.
-        final long countOfStartedActions = deploymentManagement.startScheduledActionsByRolloutGroupParent(
-                rollout.getId(), rollout.getDistributionSet().getId(), rolloutGroup.getId());
-        log.debug("{} Next actions started for rollout {} and parent group {}", countOfStartedActions, rollout,
-                rolloutGroup);
-        if (countOfStartedActions > 0) {
-            // get all next scheduled groups and set them in state running
-            rolloutGroupRepository.setStatusForCildren(RolloutGroupStatus.RUNNING, rolloutGroup);
-        } else {
-            log.debug("No actions to start for next rolloutgroup of parent {} {}", rolloutGroup.getId(),
-                    rolloutGroup.getName());
-            // nothing for next group, just finish the group, this can happen
-            // e.g. if targets has been deleted after the group has been
-            // scheduled. If the group is empty now, we just finish the group if
-            // there are not actions available for this group.
-            final List<JpaRolloutGroup> findByRolloutGroupParent = rolloutGroupRepository
-                    .findByParentIdAndStatus(rolloutGroup.getId(), RolloutGroupStatus.SCHEDULED);
-            findByRolloutGroupParent.forEach(nextGroup -> {
-                if (nextGroup.isDynamic()) {
-                    nextGroup.setStatus(RolloutGroupStatus.RUNNING);
-                } else {
-                    log.debug("Rolloutgroup {} is finished, starting next group", nextGroup);
-                    nextGroup.setStatus(RolloutGroupStatus.FINISHED);
-                    rolloutGroupRepository.save(nextGroup);
-                    // find the next group to set in running state
-                    startNextGroup(rollout, nextGroup);
-                }
-            });
-        }
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutManagementTest.java
@@ -374,15 +374,12 @@ class RolloutManagementTest extends AbstractJpaIntegrationTest {
                 successCondition, errorCondition);
 
         finishActionAndDeleteTargetsOfFirstRunningGroup(createdRollout);
-
         checkSecondGroupStatusIsRunning(createdRollout);
 
         finishActionAndDeleteTargetsOfSecondRunningGroup(createdRollout);
-
         deleteAllTargetsFromThirdGroup(createdRollout);
-
+        rolloutHandler.handleAll(); // one more time to finish the second group
         verifyRolloutAndAllGroupsAreFinished(createdRollout);
-
     }
 
     @Step("Finish three actions of the rollout group and delete two targets")


### PR DESCRIPTION
when in StartNextGroupRolloutGroupSuccessAction#startNextGroup:
    1. start all scheduled actions
    2. if started are > 0 -> RUNNING, otherwise -> FINISHED (if not dynamic rollout)

what could possibly happen is that at same time:
    * because of a success condition met the JpaRolloutsExecutor triggers start the group
    * user triggers start of the next group (via RolloutsManagement#triggerNextGroup)

then it could,
    * the 'first' one succeeds to start next group
    * the second attempts to start it (JpaRolloutsExecutor found the previous had met the success condition or trigger next found it SCHEDULED and next to run)
    * the second finds no scheduled actions (just running) and decides there are no actions. So, it assumes (wrongly) no actions in group - and set it as FINISHED

This way we could have FINISHED group with still running actions