### PR TITLE
Improve DS Tag REST & management API

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/DistributionSetManagement.java
@@ -97,6 +97,17 @@ public interface DistributionSetManagement
     List<DistributionSet> assignTag(@NotEmpty Collection<Long> ids, long tagId);
 
     /**
+     * Unassign a {@link DistributionSetTag} assignment to given {@link DistributionSet}s.
+     *
+     * @param ids to assign for
+     * @param tagId to assign
+     * @return list of assigned ds
+     * @throws EntityNotFoundException if tag with given ID does not exist or (at least one) of the distribution sets.
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
+    List<DistributionSet> unassignTag(@NotEmpty Collection<Long> ids, long tagId);
+
+    /**
      * Creates a list of distribution set meta data entries.
      *
      * @param id
@@ -453,25 +464,6 @@ public interface DistributionSetManagement
     boolean isInUse(long id);
 
     /**
-     * Toggles {@link DistributionSetTag} assignment to given
-     * {@link DistributionSet}s by means that if some (or all) of the targets in
-     * the list have the {@link Tag} not yet assigned, they will be. Only if all
-     * of theme have the tag already assigned they will be removed instead.
-     *
-     * @param ids
-     *            to toggle for
-     * @param tagName
-     *            to toggle
-     * @return {@link DistributionSetTagAssignmentResult} with all meta data of
-     *         the assignment outcome.
-     *
-     * @throws EntityNotFoundException
-     *             if given tag does not exist or (at least one) module
-     */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
-    DistributionSetTagAssignmentResult toggleTagAssignment(@NotEmpty Collection<Long> ids, @NotNull String tagName);
-
-    /**
      * Unassigns a {@link SoftwareModule} form an existing
      * {@link DistributionSet}.
      *
@@ -490,22 +482,6 @@ public interface DistributionSetManagement
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
     DistributionSet unassignSoftwareModule(long id, long moduleId);
-
-    /**
-     * Unassign a {@link DistributionSetTag} assignment to given
-     * {@link DistributionSet}.
-     *
-     * @param id
-     *            to unassign for
-     * @param tagId
-     *            to unassign
-     * @return the unassigned ds or <null> if no ds is unassigned
-     *
-     * @throws EntityNotFoundException
-     *             if set or tag with given ID does not exist
-     */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
-    DistributionSet unassignTag(long id, long tagId);
 
     /**
      * Updates a distribution set meta data value if corresponding entry exists.
@@ -585,4 +561,34 @@ public interface DistributionSetManagement
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
     void invalidate(DistributionSet distributionSet);
+
+    /**
+     * Toggles {@link DistributionSetTag} assignment to given
+     * {@link DistributionSet}s by means that if some (or all) of the targets in
+     * the list have the {@link Tag} not yet assigned, they will be. Only if all
+     * of theme have the tag already assigned they will be removed instead.
+     *
+     * @deprecated since 0.6.0 in favor of assign/unassign
+     * @param ids to toggle for
+     * @param tagName to toggle
+     * @return {@link DistributionSetTagAssignmentResult} with all meta data of the assignment outcome.
+     * @throws EntityNotFoundException if given tag does not exist or (at least one) module
+     */
+    @Deprecated(forRemoval = true)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
+    DistributionSetTagAssignmentResult toggleTagAssignment(@NotEmpty Collection<Long> ids, @NotNull String tagName);
+
+
+    /**
+     * Unassign a {@link DistributionSetTag} assignment to given {@link DistributionSet}.
+     *
+     * @deprecated since 0.6.0 in favor of unassignTag(List<Long>, long)
+     * @param id to unassign for
+     * @param tagId to unassign
+     * @return the unassigned ds or <null> if no ds is unassigned
+     * @throws EntityNotFoundException if set or tag with given ID does not exist
+     */
+    @Deprecated(forRemoval = true)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
+    DistributionSet unassignTag(long id, long tagId);
 }

--- a/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtDistributionSetTagRestApi.java
+++ b/hawkbit-rest/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtDistributionSetTagRestApi.java
@@ -338,49 +338,47 @@ public interface MgmtDistributionSetTagRestApi {
             String rsqlParam);
 
     /**
-     * Handles the POST request to toggle the assignment of distribution sets by
-     * the given tag id.
+     * Handles the POST request to assign distribution sets to the given tag id.
      *
      * @param distributionsetTagId
      *            the ID of the distribution set tag to retrieve
      * @param assignedDSRequestBodies
-     *            list of distribution set ids to be toggled
+     *            list of distribution sets ids to be assigned
      *
-     * @return the list of assigned distribution sets and unassigned
-     *         distribution sets.
+     * @return the list of assigned distribution set.
      */
-    @Operation(summary = "Toggle the assignment of distribution sets by the given tag id",
-            description = "Handles the POST request of toggle distribution assignment. The request body must " +
-                    "always be a list of distribution set ids.")
+    @Operation(summary = "Assign distribution set to the given tag id",
+            description = "Handles the POST request of distribution assignment. Already assigned distribution will " +
+                    "be ignored.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-        @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters", 
-                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
-        @ApiResponse(responseCode = "401", description = "The request requires user authentication.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", 
-                description = "Insufficient permissions, entity is not allowed to be changed (i.e. read-only) or " +
-                        "data volume restriction applies.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
-                "user in another request at the same time. You may retry your modification request.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
-                "supported by the server for this resource.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
-                "and the client has to wait another second.", 
-                content = @Content(mediaType = "application/json", schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403",
+                    description = "Insufficient permissions, entity is not allowed to be changed (i.e. read-only) or " +
+                            "data volume restriction applies.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
+                    "user in another request at the same time. You may retry your modification request.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
+                    "supported by the server for this resource.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true)))
     })
-    @PostMapping(value = MgmtRestConstants.DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING
-            + MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING + "/toggleTagAssignment")
-    ResponseEntity<MgmtDistributionSetTagAssigmentResult> toggleTagAssignment(
+    @PostMapping(value = MgmtRestConstants.DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING +
+            MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING + "/{distributionsetId}")
+    ResponseEntity<Void> assignTag(
             @PathVariable("distributionsetTagId") Long distributionsetTagId,
-            List<MgmtAssignedDistributionSetRequestBody> assignedDSRequestBodies);
+            @PathVariable("distributionsetId") Long distributionsetId);
 
     /**
      * Handles the POST request to assign distribution sets to the given tag id.
@@ -423,18 +421,15 @@ public interface MgmtDistributionSetTagRestApi {
             + MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING, consumes = {
                     MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE }, produces = {
                             MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
-    ResponseEntity<List<MgmtDistributionSet>> assignDistributionSets(
+    ResponseEntity<List<MgmtDistributionSet>> assignTag(
             @PathVariable("distributionsetTagId") Long distributionsetTagId,
             List<MgmtAssignedDistributionSetRequestBody> assignedDSRequestBodies);
 
     /**
-     * Handles the DELETE request to unassign one distribution set from the
-     * given tag id.
+     * Handles the DELETE request to unassign one distribution set from the given tag id.
      *
-     * @param distributionsetTagId
-     *            the ID of the distribution set tag
-     * @param distributionsetId
-     *            the ID of the distribution set to unassign
+     * @param distributionsetTagId the ID of the distribution set tag
+     * @param distributionsetId the ID of the distribution set to unassign
      * @return http status code
      */
     @Operation(summary = "Unassign one distribution set from the given tag id",
@@ -459,9 +454,89 @@ public interface MgmtDistributionSetTagRestApi {
                 "and the client has to wait another second.", 
                 content = @Content(mediaType = "application/json", schema = @Schema(hidden = true)))
     })
-    @DeleteMapping(value = MgmtRestConstants.DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING
-            + MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING + "/{distributionsetId}")
-    ResponseEntity<Void> unassignDistributionSet(@PathVariable("distributionsetTagId") Long distributionsetTagId,
+    @DeleteMapping(value = MgmtRestConstants.DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING +
+            MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING + "/{distributionsetId}")
+    ResponseEntity<Void> unassignTag(
+            @PathVariable("distributionsetTagId") Long distributionsetTagId,
             @PathVariable("distributionsetId") Long distributionsetId);
 
+    /**
+     * Handles the DELETE request to unassign one distribution set from the given tag id.
+     *
+     * @param distributionsetTagId the ID of the distribution set tag
+     * @param distributionsetId the ID of the distribution set to unassign
+     * @return http status code
+     */
+    @Operation(summary = "Unassign multiple distribution sets from the given tag id",
+            description = "Handles the DELETE request of unassign the given distribution.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403",
+                    description = "Insufficient permissions, entity is not allowed to be changed (i.e. read-only) or " +
+                            "data volume restriction applies.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "Distribution Set Tag not found.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true)))
+    })
+    @DeleteMapping(value = MgmtRestConstants.DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING +
+            MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING)
+    ResponseEntity<Void> unassignTag(
+            @PathVariable("distributionsetTagId") Long distributionsetTagId,
+            List<Long> distributionsetId);
+
+    /**
+     * Handles the POST request to toggle the assignment of distribution sets by
+     * the given tag id.
+     *
+     * @param distributionsetTagId
+     *            the ID of the distribution set tag to retrieve
+     * @param assignedDSRequestBodies
+     *            list of distribution set ids to be toggled
+     *
+     * @return the list of assigned distribution sets and unassigned
+     *         distribution sets.
+     */
+    @Operation(summary = "[DEPRECATED] Toggle the assignment of distribution sets by the given tag id",
+            description = "Handles the POST request of toggle distribution assignment. The request body must " +
+                    "always be a list of distribution set ids.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403",
+                    description = "Insufficient permissions, entity is not allowed to be changed (i.e. read-only) or " +
+                            "data volume restriction applies.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
+                    "user in another request at the same time. You may retry your modification request.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
+                    "supported by the server for this resource.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true)))
+    })
+    @PostMapping(value = MgmtRestConstants.DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING
+            + MgmtRestConstants.DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING + "/toggleTagAssignment")
+    ResponseEntity<MgmtDistributionSetTagAssigmentResult> toggleTagAssignment(
+            @PathVariable("distributionsetTagId") Long distributionsetTagId,
+            List<MgmtAssignedDistributionSetRequestBody> assignedDSRequestBodies);
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResource.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResource.java
@@ -163,6 +163,57 @@ public class MgmtDistributionSetTagResource implements MgmtDistributionSetTagRes
     }
 
     @Override
+    public ResponseEntity<Void> assignTag(
+            @PathVariable("distributionsetTagId") final Long distributionsetTagId,
+            @PathVariable("distributionsetId") final Long distributionsetId) {
+        log.debug("Assign ds {} for ds tag {}", distributionsetId, distributionsetTagId);
+        this.distributionSetManagement.assignTag(List.of(distributionsetId), distributionsetTagId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<List<MgmtDistributionSet>> assignTag(
+            @PathVariable("distributionsetTagId") final Long distributionsetTagId,
+            @RequestBody final List<MgmtAssignedDistributionSetRequestBody> assignedDSRequestBodies) {
+        log.debug("Assign DistributionSet {} for ds tag {}", assignedDSRequestBodies.size(), distributionsetTagId);
+        final List<DistributionSet> assignedDs = this.distributionSetManagement
+                .assignTag(findDistributionSetIds(assignedDSRequestBodies), distributionsetTagId);
+        log.debug("Assigned DistributionSet {}", assignedDs.size());
+        return ResponseEntity.ok(MgmtDistributionSetMapper.toResponseDistributionSets(assignedDs));
+    }
+
+    @Override
+    public ResponseEntity<Void> unassignTag(
+            @PathVariable("distributionsetTagId") final Long distributionsetTagId,
+            @PathVariable("distributionsetId") final Long distributionsetId) {
+        log.debug("Unassign ds {} for ds tag {}", distributionsetId, distributionsetTagId);
+        this.distributionSetManagement.unassignTag(List.of(distributionsetId), distributionsetTagId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> unassignTag(
+            @PathVariable("distributionsetTagId") final Long distributionsetTagId,
+            @RequestBody final List<Long> distributionsetIds) {
+        log.debug("Unassign DistributionSet {} for ds tag {}", distributionsetIds.size(), distributionsetTagId);
+        final List<DistributionSet> assignedDs = this.distributionSetManagement
+                .unassignTag(distributionsetIds, distributionsetTagId);
+        log.debug("Unassigned DistributionSet {}", assignedDs.size());
+        return ResponseEntity.ok().build();
+    }
+
+    private DistributionSetTag findDistributionTagById(final Long distributionsetTagId) {
+        return distributionSetTagManagement.get(distributionsetTagId)
+                .orElseThrow(() -> new EntityNotFoundException(DistributionSetTag.class, distributionsetTagId));
+    }
+
+    private static List<Long> findDistributionSetIds(
+            final List<MgmtAssignedDistributionSetRequestBody> assignedDistributionSetRequestBodies) {
+        return assignedDistributionSetRequestBodies.stream()
+                .map(MgmtAssignedDistributionSetRequestBody::getDistributionSetId).collect(Collectors.toList());
+    }
+
+    @Override
     public ResponseEntity<MgmtDistributionSetTagAssigmentResult> toggleTagAssignment(
             @PathVariable("distributionsetTagId") final Long distributionsetTagId,
             @RequestBody final List<MgmtAssignedDistributionSetRequestBody> assignedDSRequestBodies) {
@@ -184,36 +235,5 @@ public class MgmtDistributionSetTagResource implements MgmtDistributionSetTagRes
                 assigmentResult.getUnassigned());
 
         return ResponseEntity.ok(tagAssigmentResultRest);
-    }
-
-    @Override
-    public ResponseEntity<List<MgmtDistributionSet>> assignDistributionSets(
-            @PathVariable("distributionsetTagId") final Long distributionsetTagId,
-            @RequestBody final List<MgmtAssignedDistributionSetRequestBody> assignedDSRequestBodies) {
-        log.debug("Assign DistributionSet {} for ds tag {}", assignedDSRequestBodies.size(), distributionsetTagId);
-        final List<DistributionSet> assignedDs = this.distributionSetManagement
-                .assignTag(findDistributionSetIds(assignedDSRequestBodies), distributionsetTagId);
-        log.debug("Assigned DistributionSet {}", assignedDs.size());
-        return ResponseEntity.ok(MgmtDistributionSetMapper.toResponseDistributionSets(assignedDs));
-    }
-
-    @Override
-    public ResponseEntity<Void> unassignDistributionSet(
-            @PathVariable("distributionsetTagId") final Long distributionsetTagId,
-            @PathVariable("distributionsetId") final Long distributionsetId) {
-        log.debug("Unassign ds {} for ds tag {}", distributionsetId, distributionsetTagId);
-        this.distributionSetManagement.unassignTag(distributionsetId, distributionsetTagId);
-        return ResponseEntity.ok().build();
-    }
-
-    private DistributionSetTag findDistributionTagById(final Long distributionsetTagId) {
-        return distributionSetTagManagement.get(distributionsetTagId)
-                .orElseThrow(() -> new EntityNotFoundException(DistributionSetTag.class, distributionsetTagId));
-    }
-
-    private static List<Long> findDistributionSetIds(
-            final List<MgmtAssignedDistributionSetRequestBody> assignedDistributionSetRequestBodies) {
-        return assignedDistributionSetRequestBodies.stream()
-                .map(MgmtAssignedDistributionSetRequestBody::getDistributionSetId).collect(Collectors.toList());
     }
 }

--- a/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResourceTest.java
+++ b/hawkbit-rest/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTagResourceTest.java
@@ -345,7 +345,7 @@ public class MgmtDistributionSetTagResourceTest extends AbstractManagementApiInt
     @ExpectEvents({ @Expect(type = DistributionSetTagCreatedEvent.class, count = 1),
             @Expect(type = DistributionSetCreatedEvent.class, count = 2),
             @Expect(type = DistributionSetUpdatedEvent.class, count = 2) })
-    public void assignDistributionSets() throws Exception {
+    public void assignTag() throws Exception {
         final DistributionSetTag tag = testdataFactory.createDistributionSetTags(1).get(0);
         final int setsAssigned = 2;
         final List<DistributionSet> sets = testdataFactory.createDistributionSetsWithoutModules(setsAssigned);


### PR DESCRIPTION
* added methods to unassign by multiple ds
* deprecated toggle assigments - too complex to undestand
* deprecated unassign (management) of single ds  - in favour of methods with multiple ds