### PR TITLE
add flywaydb postgre dependency

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-jpa/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>flyway-mysql</artifactId>
         </dependency>
         <dependency>
+             <groupId>org.flywaydb</groupId>
+             <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>cz.jirutka.rsql</groupId>
             <artifactId>rsql-parser</artifactId>
         </dependency>


### PR DESCRIPTION
Since 0.6.1, hawkbit with postgre is not yet support if not specified it in dependency https://github.com/flyway/flyway/issues/3909#issuecomment-2188173863

We only have postgre databases in our infra and we will want to keep it that way.

Thanks in advance !