### PR TITLE
Remove peek usage as advised by sonar - mainly for debugging

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDistributionSetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaDistributionSetManagement.java
@@ -239,7 +239,11 @@ public class JpaDistributionSetManagement implements DistributionSetManagement {
             distributionSetRepository.saveAll(
                     setsFound.stream()
                             .filter(set -> assigned.contains(set.getId()))
-                            .peek(toSoftDelete -> toSoftDelete.setDeleted(true))
+                            .map(toSoftDelete -> {
+                                // don't use peek since it is by documentation mainly for debugging and could be skipped in some cases
+                                toSoftDelete.setDeleted(true);
+                                return toSoftDelete;
+                            })
                             .toList());
             targetFilterQueryRepository.unsetAutoAssignDistributionSetAndActionTypeAndAccessContext(assigned.toArray(new Long[0]));
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/OfflineDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/OfflineDsAssignmentStrategy.java
@@ -114,13 +114,14 @@ public class OfflineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
 //                    targetRepository
 //                            .findAll(AccessController.Operation.UPDATE, targetRepository.byIdsSpec(targetIdsChunk))
 //                            .stream()
-//                            .peek(target -> {
+//                            .map(target -> {
 //                                target.setAssignedDistributionSet(set);
 //                                target.setInstalledDistributionSet(set);
 //                                target.setInstallationDate(now);
 //                                target.setLastModifiedAt(now);
 //                                target.setLastModifiedBy(currentUser);
 //                                target.setUpdateStatus(TargetUpdateStatus.IN_SYNC);
+//                                return target;
 //                            })
 //                            .toList());
         });

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/OnlineDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/OnlineDsAssignmentStrategy.java
@@ -139,11 +139,12 @@ public class OnlineDsAssignmentStrategy extends AbstractDsAssignmentStrategy {
 //                targetRepository
 //                        .findAll(AccessController.Operation.UPDATE, targetRepository.byIdsSpec(targetIdsChunk))
 //                        .stream()
-//                        .peek(target -> {
+//                        .map(target -> {
 //                            target.setAssignedDistributionSet(set);
 //                            target.setLastModifiedAt(now);
 //                            target.setLastModifiedBy(currentUser);
 //                            target.setUpdateStatus(TargetUpdateStatus.PENDING);
+//                            return target;
 //                        })
 //                        .toList());
         });

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DeploymentManagementTest.java
@@ -558,8 +558,12 @@ class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         assertThat(getResultingActionCount(assignmentResults)).isEqualTo(4);
         targetIds.forEach(controllerId -> {
             final List<Long> assignedDsIds = deploymentManagement.findActionsByTarget(controllerId, PAGE).stream()
-                    .peek(a -> assertThat(a.getInitiatedBy()).as("Actions should be initiated by current user")
-                            .isEqualTo(tenantAware.getCurrentUsername()))
+                    .map(a -> {
+                        // don't use peek since it is by documentation mainly for debugging and could be skipped in some cases
+                        assertThat(a.getInitiatedBy()).as("Actions should be initiated by current user")
+                                .isEqualTo(tenantAware.getCurrentUsername());
+                        return a;
+                    })
                     .map(action -> action.getDistributionSet().getId()).collect(Collectors.toList());
             assertThat(assignedDsIds).containsExactlyInAnyOrderElementsOf(dsIds);
         });
@@ -662,8 +666,12 @@ class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         targets.forEach(target -> {
             final List<Long> assignedDsIds = deploymentManagement.findActionsByTarget(target.getControllerId(), PAGE)
                     .stream()
-                    .peek(a -> assertThat(a.getInitiatedBy()).as("Initiated by current user")
-                            .isEqualTo(tenantAware.getCurrentUsername()))
+                    .map(a -> {
+                        // don't use peek since it is by documentation mainly for debugging and could be skipped in some cases
+                        assertThat(a.getInitiatedBy()).as("Initiated by current user")
+                                .isEqualTo(tenantAware.getCurrentUsername());
+                        return a;
+                    })
                     .map(action -> action.getDistributionSet().getId()).collect(Collectors.toList());
             assertThat(assignedDsIds).containsExactlyInAnyOrderElementsOf(dsIds);
         });


### PR DESCRIPTION
By API Stream.peek is mainly for debugging and could be skiped in some cases