### PR TITLE
Fix pause of rollout on error condition

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/PauseRolloutGroupAction.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/PauseRolloutGroupAction.java
@@ -43,12 +43,23 @@ public class PauseRolloutGroupAction implements RolloutGroupActionEvaluator<Roll
 
     @Override
     public void exec(final Rollout rollout, final RolloutGroup rolloutG) {
+
+        /*
+            refresh latest rollout state in order to escape cases when
+            previous group have matched error condition and paused the rollout
+            and this one tries to pause the rollout too but throws an exception
+            and rollbacks rollout processing transaction
+         */
+        Rollout refreshedRollout = rolloutManagement.get(rollout.getId()).orElseThrow();
         final JpaRolloutGroup rolloutGroup = (JpaRolloutGroup) rolloutG;
 
         systemSecurityContext.runAsSystem(() -> {
             rolloutGroup.setStatus(RolloutGroupStatus.ERROR);
             rolloutGroupRepository.save(rolloutGroup);
-            rolloutManagement.pauseRollout(rollout.getId());
+            if (Rollout.RolloutStatus.PAUSED != refreshedRollout.getStatus()) {
+                // if only the latest state is != paused then pause
+                rolloutManagement.pauseRollout(rollout.getId());
+            }
             return null;
         });
     }


### PR DESCRIPTION
This fixes the following case :
During rollout processing (which is ran in a transaction per rollout) all rollout groups are being processed one by one
if a group matches error condition - group status goes  to error and rollout is being paused.
But
If previous group have matched error condition and paused the rollout
and the current one matches also the error condition and tries to pause the rollout too - this will throw an exception because rollout is already in paused state and will rollback the rollout processing transaction which will lead us on initial state.