### PR TITLE
Fix 'HHH000038: Composite-id class does not override equals(): org.ec…

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/RolloutTargetGroupId.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/RolloutTargetGroupId.java
@@ -12,6 +12,7 @@ package org.eclipse.hawkbit.repository.jpa.model;
 import java.io.Serial;
 import java.io.Serializable;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
@@ -22,6 +23,7 @@ import org.eclipse.hawkbit.repository.model.Target;
  */
 @NoArgsConstructor // Default constructor for JPA
 @Getter
+@EqualsAndHashCode
 public class RolloutTargetGroupId implements Serializable {
 
     @Serial


### PR DESCRIPTION
…lipse.hawkbit.repository.jpa.model.RolloutTargetGroupI'