### PR TITLE
Introduce parallel rollout processing

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/BlockWhenFullPolicy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/BlockWhenFullPolicy.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hawkbit.repository.jpa;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class BlockWhenFullPolicy implements RejectedExecutionHandler {
+  @Override
+  public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+    try {
+      // Because queueCapacity=0 => SynchronousQueue
+      // This put(...) call blocks if both threads are busy,
+      // until a thread is free
+      executor.getQueue().put(r);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RejectedExecutionException("Interrupted while waiting to queue task", e);
+    }
+  }
+}


### PR DESCRIPTION
- Introduce a ThreadPoolTaskExecutor for parallel rollout execution
- Introduce a BlockWhenFullPolicy RejectedExecutionHandler to block scheduler submissions if all threads (default : 2) are occupied.