### PR TITLE
Remove unnecessary JsonProperty annotations

### DIFF
--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedback.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionFeedback.java
@@ -71,5 +71,4 @@ public class DdiActionFeedback {
     public DdiActionFeedback(final DdiStatus status) {
         this(status, null);
     }
-
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistory.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActionHistory.java
@@ -16,8 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.Data;
 import org.eclipse.hawkbit.ddi.rest.api.DdiRootControllerRestApi;
 
 /**
@@ -30,31 +29,28 @@ import org.eclipse.hawkbit.ddi.rest.api.DdiRootControllerRestApi;
  * </ol>
  * that were sent to server earlier by the controller using {@link DdiActionFeedback}.
  */
-@EqualsAndHashCode
-@ToString
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({ "status", "messages" })
 public class DdiActionHistory {
 
-    @JsonProperty("status")
     @Schema(description = "Status of the deployment based on previous feedback by the device", example = "RUNNING")
-    private final String actionStatus;
+    private final String status;
 
-    @JsonProperty("messages")
     @Schema(description = "Messages are previously sent to the feedback channel in LIFO order by the device. Note: The first status message is set by the system and describes the trigger of the deployment")
     private final List<String> messages;
 
     /**
      * Parameterized constructor for creating {@link DdiActionHistory}.
      *
-     * @param actionStatus is the current action status at the server
+     * @param status is the current action status at the server
      * @param messages is a list of messages retrieved from action history.
      */
     @JsonCreator
     public DdiActionHistory(
-            @JsonProperty("status") final String actionStatus,
-            @JsonProperty("messages") List<String> messages) {
-        this.actionStatus = actionStatus;
+            @JsonProperty("status") final String status,
+            @JsonProperty("messages") final List<String> messages) {
+        this.status = status;
         this.messages = messages;
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActivateAutoConfirmation.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiActivateAutoConfirmation.java
@@ -19,12 +19,10 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiActivateAutoConfirmation {
 
-    @JsonProperty
     @Schema(description = "Individual value (e.g. username) stored as initiator and automatically used as confirmed" +
             " user in future actions", example = "exampleUser")
     private final String initiator;
 
-    @JsonProperty
     @Schema(description = "Individual value to attach a remark which will be persisted when automatically " +
             "confirming future actions", example = "exampleRemark")
     private final String remark;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifact.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifact.java
@@ -11,6 +11,7 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -59,15 +60,22 @@ import org.springframework.hateoas.RepresentationModel;
 public class DdiArtifact extends RepresentationModel<DdiArtifact> {
 
     @NotNull
-    @JsonProperty
     @Schema(description = "File name", example = "binary.tgz")
-    private String filename;
+    private final String filename;
 
-    @JsonProperty
     @Schema(description = "Artifact hashes")
-    private DdiArtifactHash hashes;
+    private final DdiArtifactHash hashes;
 
-    @JsonProperty
     @Schema(description = "Artifact size", example = "3")
-    private Long size;
+    private final Long size;
+
+    @JsonCreator
+    public DdiArtifact(
+            @JsonProperty("filename") final String filename,
+            @JsonProperty("hashes") final DdiArtifactHash hashes,
+            @JsonProperty("size") final Long size) {
+        this.filename = filename;
+        this.hashes = hashes;
+        this.size = size;
+    }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHash.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactHash.java
@@ -9,38 +9,30 @@
  */
 package org.eclipse.hawkbit.ddi.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
 /**
  * Hashes for given Artifact
  */
-@NoArgsConstructor // needed for json create
-@Getter
-@EqualsAndHashCode
-@ToString
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiArtifactHash {
 
-    @JsonProperty
     @Schema(description = "SHA1 hash of the artifact in Base 16 format", example = "2d86c2a659e364e9abba49ea6ffcd53dd5559f05")
-    private String sha1;
+    private final String sha1;
 
-    @JsonProperty
     @Schema(description = "MD5 hash of the artifact", example = "0d1b08c34858921bc7c662b228acb7ba")
-    private String md5;
+    private final String md5;
 
-    @JsonProperty
     @JsonInclude(Include.NON_NULL)
     @Schema(description = "SHA-256 hash of the artifact in Base 16 format", example = "a03b221c6c6eae7122ca51695d456d5222e524889136394944b2f9763b483615")
-    private String sha256;
+    private final String sha256;
 
     /**
      * Public constructor.
@@ -49,7 +41,11 @@ public class DdiArtifactHash {
      * @param md5 md5 hash of the artifact
      * @param sha256 sha256 hash of the artifact
      */
-    public DdiArtifactHash(final String sha1, final String md5, final String sha256) {
+    @JsonCreator
+    public DdiArtifactHash(
+            @JsonProperty("sha1") final String sha1,
+            @JsonProperty("md5") final String md5,
+            @JsonProperty ("sha256") final String sha256) {
         this.sha1 = sha1;
         this.md5 = md5;
         this.sha256 = sha256;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiAssignedVersion.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiAssignedVersion.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.Getter;
 
 /**
  * Allow a target to declare running distribution set version
@@ -40,10 +41,5 @@ public class DdiAssignedVersion {
             @JsonProperty(value = "version", required = true) final String version) {
         this.name = name;
         this.version = version;
-    }
-
-    @Override
-    public String toString() {
-        return "DdiInstalledVersion{" + "name='" + name + '\'' + ", version='" + version + '\'' + '}';
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiAutoConfirmationState.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiAutoConfirmationState.java
@@ -11,17 +11,17 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.hateoas.RepresentationModel;
 
-@NoArgsConstructor // needed for json create
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -32,25 +32,26 @@ public class DdiAutoConfirmationState extends RepresentationModel<DdiAutoConfirm
 
     @NotNull
     @Schema(example = "true")
-    private boolean active;
+    private final boolean active;
 
     @Schema(example = "exampleUserId")
-    private String initiator;
+    private final String initiator;
 
     @Schema(example = "exampleRemark")
-    private String remark;
+    private final String remark;
 
     @Schema(example = "1691065895439")
-    private Long activatedAt;
+    private final Long activatedAt;
 
-    public static DdiAutoConfirmationState active(final long activatedAt) {
-        final DdiAutoConfirmationState state = new DdiAutoConfirmationState();
-        state.setActive(true);
-        state.setActivatedAt(activatedAt);
-        return state;
-    }
-
-    public static DdiAutoConfirmationState disabled() {
-        return new DdiAutoConfirmationState();
+    @JsonCreator
+    public DdiAutoConfirmationState(
+            @JsonProperty("active") final boolean active,
+            @JsonProperty("initiator") final String initiator,
+            @JsonProperty("remark") final String remark,
+            @JsonProperty("activatedAt") final Long activatedAt) {
+        this.active = active;
+        this.initiator = initiator;
+        this.remark = remark;
+        this.activatedAt = activatedAt;
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiChunk.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiChunk.java
@@ -14,54 +14,43 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
 /**
  * Deployment chunks.
  */
-@NoArgsConstructor // needed for json create
-@Getter
-@EqualsAndHashCode
-@ToString
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiChunk {
 
-    @JsonProperty("part")
     @NotNull
     @Schema(description = "Type of the chunk, e.g. firmware, bundle, app. In update server mapped to Software Module Type")
-    private String part;
+    private final String part;
 
-    @JsonProperty("version")
     @NotNull
     @Schema(description = "Software version of the chunk", example = "1.2.0")
-    private String version;
+    private final String version;
 
-    @JsonProperty("name")
     @NotNull
     @Schema(description = "Name of the chunk")
-    private String name;
+    private final String name;
 
-    @JsonProperty("encrypted")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "If encrypted")
-    private Boolean encrypted;
+    private final Boolean encrypted;
 
-    @JsonProperty("artifacts")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "List of artifacts")
-    private List<DdiArtifact> artifacts;
+    private final List<DdiArtifact> artifacts;
 
-    @JsonProperty("metadata")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "Meta data of the respective software module that has been marked with 'target visible'")
-    private List<DdiMetadata> metadata;
+    private final List<DdiMetadata> metadata;
 
     /**
      * Constructor.
@@ -73,9 +62,14 @@ public class DdiChunk {
      * @param artifacts download information
      * @param metadata optional as additional information for the target/device
      */
+    @JsonCreator
     public DdiChunk(
-            final String part, final String version, final String name, final Boolean encrypted,
-            final List<DdiArtifact> artifacts, final List<DdiMetadata> metadata) {
+            @JsonProperty("part") final String part,
+            @JsonProperty("version") final String version,
+            @JsonProperty("name") final String name,
+            @JsonProperty("encrypted") final Boolean encrypted,
+            @JsonProperty("artifacts") final List<DdiArtifact> artifacts,
+            @JsonProperty("metadata") final List<DdiMetadata> metadata) {
         this.part = part;
         this.version = version;
         this.name = name;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfig.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfig.java
@@ -9,37 +9,32 @@
  */
 package org.eclipse.hawkbit.ddi.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
 /**
  * Standard configuration for the target.
  */
-@NoArgsConstructor // needed for json deserialization
-@Getter
-@EqualsAndHashCode
-@ToString
+@Data
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "DDI controller configuration")
 public class DdiConfig {
 
-    @JsonProperty
-    private DdiPolling polling;
+    private final DdiPolling polling;
 
     /**
      * Constructor.
      *
      * @param polling configuration of the polling for the target
      */
-    public DdiConfig(final DdiPolling polling) {
+    @JsonCreator
+    public DdiConfig(@JsonProperty("polling") final DdiPolling polling) {
         this.polling = polling;
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfirmationBase.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfirmationBase.java
@@ -11,13 +11,13 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.hateoas.RepresentationModel;
 
@@ -25,8 +25,7 @@ import org.springframework.hateoas.RepresentationModel;
  * Confirmation base response.
  * Set order to place links at last.
  */
-@NoArgsConstructor // needed for json create
-@Getter
+@Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -54,11 +53,12 @@ import org.springframework.hateoas.RepresentationModel;
                 }""")
 public class DdiConfirmationBase extends RepresentationModel<DdiConfirmationBase> {
 
-    @JsonProperty("autoConfirm")
     @NotNull
-    private DdiAutoConfirmationState autoConfirm;
+    private final DdiAutoConfirmationState autoConfirm;
 
-    public DdiConfirmationBase(final DdiAutoConfirmationState autoConfirmState) {
-        this.autoConfirm = autoConfirmState;
+    @JsonCreator
+    public DdiConfirmationBase(
+            @JsonProperty(value = "autoConfirm", required = true) final DdiAutoConfirmationState autoConfirm) {
+        this.autoConfirm = autoConfirm;
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfirmationBaseAction.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiConfirmationBaseAction.java
@@ -11,22 +11,22 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.ToString;
 import org.springframework.hateoas.RepresentationModel;
 
 /**
  * Update action resource.
  */
-@NoArgsConstructor // needed for json create
-@Getter
+@Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -201,27 +201,23 @@ import org.springframework.hateoas.RepresentationModel;
                 }""")
 public class DdiConfirmationBaseAction extends RepresentationModel<DdiConfirmationBaseAction> {
 
-    @JsonProperty("id")
     @NotNull
     @Schema(description = "Id of the action", example = "6")
-    private String id;
+    private final String id;
 
-    @JsonProperty("confirmation")
     @NotNull
     @Schema(description = "Deployment confirmation operation")
-    private DdiDeployment confirmation;
+    private final DdiDeployment confirmation;
 
     /**
-     * Action history containing current action status and a list of feedback
-     * messages received earlier from the controller.
+     * Action history containing current action status and a list of feedback messages received earlier from the controller.
      */
-    @JsonProperty("actionHistory")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = """
             (Optional) GET parameter to retrieve a given number of messages which are previously
             provided by the device. Useful if the devices sent state information to the feedback channel and never
             stored them locally""")
-    private DdiActionHistory actionHistory;
+    private final DdiActionHistory actionHistory;
 
     /**
      * Constructor.
@@ -230,7 +226,11 @@ public class DdiConfirmationBaseAction extends RepresentationModel<DdiConfirmati
      * @param confirmation chunk details
      * @param actionHistory containing current action status and a list of feedback messages received earlier from the controller.
      */
-    public DdiConfirmationBaseAction(final String id, final DdiDeployment confirmation, final DdiActionHistory actionHistory) {
+    @JsonCreator
+    public DdiConfirmationBaseAction(
+            @JsonProperty(value = "id", required = true) @NonNull final String id,
+            @JsonProperty(value = "confirmation", required = true) @NonNull final DdiDeployment confirmation,
+            @JsonProperty("actionHistory") final DdiActionHistory actionHistory) {
         this.id = id;
         this.confirmation = confirmation;
         this.actionHistory = actionHistory;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBase.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiControllerBase.java
@@ -9,22 +9,21 @@
  */
 package org.eclipse.hawkbit.ddi.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.hateoas.RepresentationModel;
 
 /**
  * {@link DdiControllerBase} resource content.
  */
-@NoArgsConstructor // needed for json deserialization
-@Getter
+@Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @JsonInclude(Include.NON_NULL)
@@ -56,15 +55,15 @@ import org.springframework.hateoas.RepresentationModel;
                 }""")
 public class DdiControllerBase extends RepresentationModel<DdiControllerBase> {
 
-    @JsonProperty
-    private DdiConfig config;
+    private final DdiConfig config;
 
     /**
      * Constructor.
      *
      * @param config configuration of the SP target
      */
-    public DdiControllerBase(final DdiConfig config) {
+    @JsonCreator
+    public DdiControllerBase(@JsonProperty("config") final DdiConfig config) {
         this.config = config;
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeployment.java
@@ -14,23 +14,18 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
 /**
  * Detailed update action information.
  */
-@NoArgsConstructor // needed for json create
-@Getter
-@EqualsAndHashCode
-@ToString
+@Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiDeployment {
@@ -38,22 +33,21 @@ public class DdiDeployment {
     @Schema(description = """
             Handling for the download part of the provisioning process ('skip': do not download yet, 'attempt': server asks
             to download, 'forced': server requests immediate download)""")
-    private HandlingType download;
+    private final HandlingType download;
 
     @Schema(description = """
             Handling for the update part of the provisioning process ('skip': do not update yet,
             'attempt': server asks to update, 'forced': server requests immediate update)""")
-    private HandlingType update;
+    private final HandlingType update;
 
-    @JsonProperty("chunks")
     @NotNull
     @Schema(description = "Software chunks of an update. In server mapped by Software Module")
-    private List<DdiChunk> chunks;
+    private final List<DdiChunk> chunks;
 
     @Schema(description = """
             Separation of download and installation by defining a maintenance window for the installation. Status shows if
             currently in a window""")
-    private DdiMaintenanceWindowStatus maintenanceWindow;
+    private final DdiMaintenanceWindowStatus maintenanceWindow;
 
     /**
      * Constructor.
@@ -66,9 +60,12 @@ public class DdiDeployment {
      *         and the update can progress) or 'unavailable' (implying that maintenance window is not available now and update should not
      *         be attempted). If there is no maintenance schedule defined, the parameter is null.
      */
+    @JsonCreator
     public DdiDeployment(
-            final HandlingType download, final HandlingType update, final List<DdiChunk> chunks,
-            final DdiMaintenanceWindowStatus maintenanceWindow) {
+            @JsonProperty("download") final HandlingType download,
+            @JsonProperty("update") final HandlingType update,
+            @JsonProperty(value = "chunks", required = true) final List<DdiChunk> chunks,
+            @JsonProperty("maintenanceWindow") final DdiMaintenanceWindowStatus maintenanceWindow) {
         this.download = download;
         this.update = update;
         this.chunks = chunks;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBase.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiDeploymentBase.java
@@ -11,22 +11,21 @@ package org.eclipse.hawkbit.ddi.json.model;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.hateoas.RepresentationModel;
 
 /**
  * Update action resource.
  */
-@NoArgsConstructor // needed for json create
-@Getter
+@Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -198,24 +197,21 @@ import org.springframework.hateoas.RepresentationModel;
         }""")
 public class DdiDeploymentBase extends RepresentationModel<DdiDeploymentBase> {
 
-    @JsonProperty("id")
     @NotNull
     @Schema(description = "Id of the action", example = "8")
-    private String id;
+    private final String id;
 
-    @JsonProperty("deployment")
     @NotNull
     @Schema(description = "Detailed deployment operation")
-    private DdiDeployment deployment;
+    private final DdiDeployment deployment;
 
     /**
      * Action history containing current action status and a list of feedback
      * messages received earlier from the controller.
      */
-    @JsonProperty("actionHistory")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "Current deployment state")
-    private DdiActionHistory actionHistory;
+    private final DdiActionHistory actionHistory;
 
     /**
      * Constructor.
@@ -224,7 +220,11 @@ public class DdiDeploymentBase extends RepresentationModel<DdiDeploymentBase> {
      * @param deployment details
      * @param actionHistory containing current action status and a list of feedback messages received earlier from the controller.
      */
-    public DdiDeploymentBase(final String id, final DdiDeployment deployment, final DdiActionHistory actionHistory) {
+    @JsonCreator
+    public DdiDeploymentBase(
+            @JsonProperty(value = "id", required = true) final String id,
+            @JsonProperty(value = "deployment", required = true) final DdiDeployment deployment,
+            @JsonProperty("actionHistory") final DdiActionHistory actionHistory) {
         this.id = id;
         this.deployment = deployment;
         this.actionHistory = actionHistory;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadata.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiMetadata.java
@@ -24,12 +24,10 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DdiMetadata {
 
-    @JsonProperty
     @NotNull
     @Schema(description = "Key of meta data entry")
     private final String key;
 
-    @JsonProperty
     @NotNull
     @Schema(description = "Value of meta data entry")
     private final String value;

--- a/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiPolling.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/main/java/org/eclipse/hawkbit/ddi/json/model/DdiPolling.java
@@ -9,38 +9,33 @@
  */
 package org.eclipse.hawkbit.ddi.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
 /**
  * Polling interval for the SP target.
  */
-@NoArgsConstructor // needed for json create
-@Getter
-@EqualsAndHashCode
-@ToString
+@Data
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "Suggested sleep time between polls")
 public class DdiPolling {
 
-    @JsonProperty
     @Schema(description = "Sleep time in HH:MM:SS notation", pattern = "HH:MM:SS", example = "12:00:00")
-    private String sleep;
+    private final String sleep;
 
     /**
      * Constructor.
      *
      * @param sleep between polls
      */
-    public DdiPolling(final String sleep) {
+    @JsonCreator
+    public DdiPolling(@JsonProperty("sleep") final String sleep) {
         this.sleep = sleep;
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
+++ b/hawkbit-ddi/hawkbit-ddi-api/src/test/java/org/eclipse/hawkbit/ddi/json/model/DdiArtifactTest.java
@@ -39,10 +39,7 @@ class DdiArtifactTest {
         final DdiArtifactHash hashes = new DdiArtifactHash("123", "456", "789");
         final Long size = 12345L;
 
-        final DdiArtifact ddiArtifact = new DdiArtifact();
-        ddiArtifact.setFilename(filename);
-        ddiArtifact.setHashes(hashes);
-        ddiArtifact.setSize(size);
+        final DdiArtifact ddiArtifact = new DdiArtifact(filename, hashes, size);
 
         // Test
         final String serializedDdiArtifact = OBJECT_MAPPER.writeValueAsString(ddiArtifact);

--- a/hawkbit-ddi/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
+++ b/hawkbit-ddi/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DataConversionHelper.java
@@ -174,10 +174,10 @@ public final class DataConversionHelper {
     private static DdiArtifact createArtifact(
             final Target target, final ArtifactUrlHandler artifactUrlHandler,
             final Artifact artifact, final SystemManagement systemManagement, final HttpRequest request) {
-        final DdiArtifact file = new DdiArtifact();
-        file.setHashes(new DdiArtifactHash(artifact.getSha1Hash(), artifact.getMd5Hash(), artifact.getSha256Hash()));
-        file.setFilename(artifact.getFilename());
-        file.setSize(artifact.getSize());
+        final DdiArtifact file = new DdiArtifact(
+                artifact.getFilename(),
+                new DdiArtifactHash(artifact.getSha1Hash(), artifact.getMd5Hash(), artifact.getSha256Hash()),
+                artifact.getSize());
 
         final TenantMetaData tenantMetadata = systemManagement.getTenantMetadataWithoutDetails();
         artifactUrlHandler

--- a/hawkbit-ddi/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
+++ b/hawkbit-ddi/hawkbit-ddi-resource/src/main/java/org/eclipse/hawkbit/ddi/rest/resource/DdiRootController.java
@@ -775,15 +775,14 @@ public class DdiRootController implements DdiRootControllerRestApi {
 
     private DdiAutoConfirmationState getAutoConfirmationState(final String controllerId) {
         return confirmationManagement.getStatus(controllerId).map(status -> {
-            final DdiAutoConfirmationState state = DdiAutoConfirmationState.active(status.getActivatedAt());
-            state.setInitiator(status.getInitiator());
-            state.setRemark(status.getRemark());
+            final DdiAutoConfirmationState state = new DdiAutoConfirmationState(
+                    true, status.getInitiator(), status.getRemark(), status.getActivatedAt());
             log.trace("Returning state auto-conf state active [initiator='{}' | activatedAt={}] for device {}",
                     controllerId, status.getInitiator(), status.getActivatedAt());
             return state;
         }).orElseGet(() -> {
             log.trace("Returning state auto-conf state disabled for device {}", controllerId);
-            return DdiAutoConfirmationState.disabled();
+            return new DdiAutoConfirmationState(false, null, null, 0L);
         });
     }
 }

--- a/hawkbit-ddi/hawkbit-ddi-security/src/main/java/org/eclipse/hawkbit/security/controller/ControllerSecurityToken.java
+++ b/hawkbit-ddi/hawkbit-ddi-security/src/main/java/org/eclipse/hawkbit/security/controller/ControllerSecurityToken.java
@@ -29,15 +29,10 @@ public class ControllerSecurityToken {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
 
-    @JsonProperty
     private final Long tenantId;
-    @JsonProperty
     private final Long targetId;
-    @JsonProperty
     private final String controllerId;
-    @JsonProperty
     private String tenant;
-    @JsonProperty
     private Map<String, String> headers;
 
     /**

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpMessageHandlerService.java
@@ -454,17 +454,16 @@ public class AmqpMessageHandlerService extends BaseAmqpService {
 
         final Action updatedAction;
         if (actionUpdateStatus.getActionStatus() == DmfActionStatus.CONFIRMED) {
-            updatedAction = confirmationManagement.confirmAction(action.getId(),
-                    actionUpdateStatus.getCode().orElse(null), messages);
+            updatedAction = confirmationManagement.confirmAction(action.getId(), actionUpdateStatus.getCode(), messages);
         } else if (actionUpdateStatus.getActionStatus() == DmfActionStatus.DENIED) {
-            updatedAction = confirmationManagement.denyAction(action.getId(), actionUpdateStatus.getCode().orElse(null), messages);
+            updatedAction = confirmationManagement.denyAction(action.getId(), actionUpdateStatus.getCode(), messages);
         } else {
             final ActionStatusCreate actionStatus = entityFactory.actionStatus().create(action.getId()).status(status).messages(messages);
-            actionUpdateStatus.getCode().ifPresent(code -> {
+            Optional.ofNullable(actionUpdateStatus.getCode()).ifPresent(code -> {
                 actionStatus.code(code);
                 actionStatus.message("Device reported status code: " + code);
             });
-            updatedAction = ((Status.CANCELED == status) || (Status.CANCEL_REJECTED == status))
+            updatedAction = Status.CANCELED == status || Status.CANCEL_REJECTED == status
                     ? controllerManagement.addCancelActionStatus(actionStatus)
                     : controllerManagement.addUpdateActionStatus(actionStatus);
         }

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/amqp/BaseAmqpServiceTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -100,12 +102,7 @@ class BaseAmqpServiceTest {
     }
 
     private DmfActionUpdateStatus createActionStatus() {
-        final DmfActionUpdateStatus actionUpdateStatus = new DmfActionUpdateStatus(1L, DmfActionStatus.RUNNING);
-        actionUpdateStatus.setCode(2);
-        actionUpdateStatus.setSoftwareModuleId(2L);
-        actionUpdateStatus.addMessage("Message 1");
-        actionUpdateStatus.addMessage("Message 2");
-        return actionUpdateStatus;
+        return new DmfActionUpdateStatus(1L, DmfActionStatus.RUNNING, null, 2L, List.of("Message 1", "Message 2"), 2);
     }
 
 }

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AbstractAmqpServiceIntegrationTest.java
@@ -306,14 +306,9 @@ abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpIntegratio
 
         DmfCreateThing payload = null;
         if (!StringUtils.isEmpty(name) || !CollectionUtils.isEmpty(attributes)) {
-            payload = new DmfCreateThing();
-            payload.setName(name);
-
-            if (!CollectionUtils.isEmpty(attributes)) {
-                final DmfAttributeUpdate attributeUpdate = new DmfAttributeUpdate();
-                attributeUpdate.getAttributes().putAll(attributes);
-                payload.setAttributeUpdate(attributeUpdate);
-            }
+            payload = new DmfCreateThing(
+                    name, null,
+                    CollectionUtils.isEmpty(attributes) ? null : new DmfAttributeUpdate(attributes, null));
         }
 
         return createMessage(payload, messageProperties);
@@ -330,7 +325,8 @@ abstract class AbstractAmqpServiceIntegrationTest extends AbstractAmqpIntegratio
 
     protected void createAndSendActionStatusUpdateMessage(final String target, final long actionId,
             final DmfActionStatus status) {
-        final DmfActionUpdateStatus dmfActionUpdateStatus = new DmfActionUpdateStatus(actionId, status, System.currentTimeMillis());
+        final DmfActionUpdateStatus dmfActionUpdateStatus = new DmfActionUpdateStatus(
+                actionId, status, System.currentTimeMillis(), null, null, null);
 
         final Message eventMessage = createUpdateActionEventMessage(dmfActionUpdateStatus);
         eventMessage.getMessageProperties().getHeaders().put(MessageHeaderKey.THING_ID, target);

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/test/java/org/eclipse/hawkbit/integration/AmqpMessageHandlerServiceIntegrationTest.java
@@ -729,9 +729,8 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
 
         // setup
         registerAndAssertTargetWithExistingTenant(controllerId);
-        final DmfAttributeUpdate controllerAttribute = new DmfAttributeUpdate();
-        controllerAttribute.getAttributes().put("test1", "testA");
-        controllerAttribute.getAttributes().put("test2", "testB");
+        final DmfAttributeUpdate controllerAttribute = new DmfAttributeUpdate(
+                Map.of("test1", "testA", "test2", "testB"), null);
         final Message createUpdateAttributesMessage = createUpdateAttributesMessage(null, TENANT_EXIST,
                 controllerAttribute);
         createUpdateAttributesMessage.getMessageProperties().getHeaders().remove(MessageHeaderKey.THING_ID);
@@ -741,7 +740,7 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
 
         // verify
         verifyOneDeadLetterMessage();
-        final DmfAttributeUpdate controllerAttributeEmpty = new DmfAttributeUpdate();
+        final DmfAttributeUpdate controllerAttributeEmpty = new DmfAttributeUpdate(null, null);
         assertUpdateAttributes(controllerId, controllerAttributeEmpty.getAttributes());
     }
 
@@ -754,11 +753,7 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
     void updateAttributesWithWrongBody() {
         // setup
         registerAndAssertTargetWithExistingTenant(UPDATE_ATTR_TEST_CONTROLLER_ID);
-        final DmfAttributeUpdate controllerAttribute = new DmfAttributeUpdate();
-        controllerAttribute.getAttributes().put("test1", "testA");
-        controllerAttribute.getAttributes().put("test2", "testB");
-        final Message createUpdateAttributesMessageWrongBody = createUpdateAttributesMessageWrongBody(
-                UPDATE_ATTR_TEST_CONTROLLER_ID);
+        final Message createUpdateAttributesMessageWrongBody = createUpdateAttributesMessageWrongBody( UPDATE_ATTR_TEST_CONTROLLER_ID);
 
         // test
         getDmfClient().send(createUpdateAttributesMessageWrongBody);
@@ -1051,9 +1046,7 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
         removeAttributes.put("k1", "foo");
         removeAttributes.put("k3", "bar");
 
-        final DmfAttributeUpdate remove = new DmfAttributeUpdate();
-        remove.setMode(DmfUpdateMode.REMOVE);
-        remove.getAttributes().putAll(removeAttributes);
+        final DmfAttributeUpdate remove = new DmfAttributeUpdate(removeAttributes, DmfUpdateMode.REMOVE);
         sendUpdateAttributeMessage(remove);
 
         // validate
@@ -1071,9 +1064,7 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
         mergeAttributes.put("k1", "v1_modified_again");
         mergeAttributes.put("k4", "v4");
 
-        final DmfAttributeUpdate merge = new DmfAttributeUpdate();
-        merge.setMode(DmfUpdateMode.MERGE);
-        merge.getAttributes().putAll(mergeAttributes);
+        final DmfAttributeUpdate merge = new DmfAttributeUpdate(mergeAttributes, DmfUpdateMode.MERGE);
         sendUpdateAttributeMessage(merge);
 
         // validate
@@ -1091,9 +1082,7 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
         expectedAttributes.put("k2", "v2");
         expectedAttributes.put("k3", "v3");
 
-        final DmfAttributeUpdate replace = new DmfAttributeUpdate();
-        replace.setMode(DmfUpdateMode.REPLACE);
-        replace.getAttributes().putAll(expectedAttributes);
+        final DmfAttributeUpdate replace = new DmfAttributeUpdate(expectedAttributes, DmfUpdateMode.REPLACE);
         sendUpdateAttributeMessage(replace);
 
         // validate
@@ -1107,8 +1096,7 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
         expectedAttributes.put("k0", "v0");
         expectedAttributes.put("k1", "v1");
 
-        final DmfAttributeUpdate defaultUpdate = new DmfAttributeUpdate();
-        defaultUpdate.getAttributes().putAll(expectedAttributes);
+        final DmfAttributeUpdate defaultUpdate = new DmfAttributeUpdate(expectedAttributes, null);
         sendUpdateAttributeMessage(defaultUpdate);
 
         // validate
@@ -1135,10 +1123,8 @@ class AmqpMessageHandlerServiceIntegrationTest extends AbstractAmqpServiceIntegr
     }
 
     private void sendUpdateAttributesMessageWithGivenAttributes(final String key, final String value) {
-        final DmfAttributeUpdate controllerAttribute = new DmfAttributeUpdate();
-        controllerAttribute.getAttributes().put(key, value);
-        final Message message = createUpdateAttributesMessage(UPDATE_ATTR_TEST_CONTROLLER_ID, TENANT_EXIST,
-                controllerAttribute);
+        final DmfAttributeUpdate controllerAttribute = new DmfAttributeUpdate(Map.of(key, value), null);
+        final Message message = createUpdateAttributesMessage(UPDATE_ATTR_TEST_CONTROLLER_ID, TENANT_EXIST, controllerAttribute);
         getDmfClient().send(message);
     }
 

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfActionRequest.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfActionRequest.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -23,6 +24,10 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfActionRequest {
 
-    @JsonProperty
-    private Long actionId;
+    private final Long actionId;
+
+    @JsonCreator
+    public DmfActionRequest(@JsonProperty("actionId") final Long actionId) {
+        this.actionId = actionId;
+    }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfActionUpdateStatus.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfActionUpdateStatus.java
@@ -9,20 +9,15 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Setter;
 
 /**
  * JSON representation of action update status.
@@ -35,31 +30,28 @@ public class DmfActionUpdateStatus {
     private final Long actionId;
     private final DmfActionStatus actionStatus;
     private final long timestamp;
+    private final Long softwareModuleId;
+    private final List<String> message;
+    private final Integer code;
 
-    @JsonProperty
-    private Long softwareModuleId;
-
-    @Setter(AccessLevel.NONE)
-    @JsonProperty
-    private List<String> message;
-
-    @JsonProperty
-    private Integer code;
-
-    public DmfActionUpdateStatus(@JsonProperty(value = "actionId", required = true) final Long actionId,
-            @JsonProperty(value = "actionStatus", required = true) final DmfActionStatus actionStatus, @JsonProperty(value = "timestamp") final Long timestamp) {
+    @JsonCreator
+    public DmfActionUpdateStatus(
+            @JsonProperty(value = "actionId", required = true) final Long actionId,
+            @JsonProperty(value = "actionStatus", required = true) final DmfActionStatus actionStatus,
+            @JsonProperty(value = "timestamp") final Long timestamp,
+            @JsonProperty("softwareModuleId") final Long softwareModuleId,
+            @JsonProperty("message") final List<String> message,
+            @JsonProperty("code") final Integer code) {
         this.actionId = actionId;
         this.actionStatus = actionStatus;
         this.timestamp = timestamp != null ? timestamp : System.currentTimeMillis();
+        this.softwareModuleId = softwareModuleId;
+        this.message = message;
+        this.code = code;
     }
 
     public DmfActionUpdateStatus(final Long actionId, final DmfActionStatus actionStatus) {
-        this(actionId, actionStatus, null);
-    }
-
-    @JsonIgnore
-    public Optional<Integer> getCode() {
-        return Optional.ofNullable(code);
+        this(actionId, actionStatus, null, null, null, 0);
     }
 
     public List<String> getMessage() {
@@ -68,26 +60,5 @@ public class DmfActionUpdateStatus {
         }
 
         return message;
-    }
-
-    public boolean addMessage(final String message) {
-        if (this.message == null) {
-            this.message = new ArrayList<>();
-        }
-
-        return this.message.add(message);
-    }
-
-    public boolean addMessage(final Collection<String> messages) {
-        if (messages == null || messages.isEmpty()) {
-            return false;
-        }
-
-        if (message == null) {
-            message = new ArrayList<>(messages);
-            return true;
-        }
-
-        return message.addAll(messages);
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfArtifact.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfArtifact.java
@@ -12,6 +12,7 @@ package org.eclipse.hawkbit.dmf.json.model;
 import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -26,22 +27,23 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfArtifact {
 
-    @JsonProperty
-    private String filename;
-    @JsonProperty
-    private DmfArtifactHash hashes;
-    @JsonProperty
-    private long size;
-    @JsonProperty
-    private long lastModified;
-    @JsonProperty
-    private Map<String, String> urls;
+    private final String filename;
+    private final DmfArtifactHash hashes;
+    private final long size;
+    private final long lastModified;
+    private final Map<String, String> urls;
 
-    public Map<String, String> getUrls() {
-        if (urls == null) {
-            return Collections.emptyMap();
-        }
-
-        return Collections.unmodifiableMap(urls);
+    @JsonCreator
+    public DmfArtifact(
+            @JsonProperty("filename") final String filename,
+            @JsonProperty("hashes") final DmfArtifactHash hashes,
+            @JsonProperty("size") final long size,
+            @JsonProperty("lastModified") final long lastModified,
+            @JsonProperty("urls") final Map<String, String> urls) {
+        this.filename = filename;
+        this.hashes = hashes;
+        this.size = size;
+        this.lastModified = lastModified;
+        this.urls = urls == null ? Collections.emptyMap() : Collections.unmodifiableMap(urls);
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfArtifactHash.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfArtifactHash.java
@@ -19,10 +19,8 @@ import lombok.Data;
 @Data
 public class DmfArtifactHash {
 
-    @JsonProperty
-    private String sha1;
-    @JsonProperty
-    private String md5;
+    private final String sha1;
+    private final String md5;
 
     /**
      * Constructor.

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfAttributeUpdate.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfAttributeUpdate.java
@@ -9,9 +9,10 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -26,9 +27,14 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfAttributeUpdate {
 
-    @JsonProperty
-    private final Map<String, String> attributes = new HashMap<>();
+    private final Map<String, String> attributes;
+    private final DmfUpdateMode mode;
 
-    @JsonProperty
-    private DmfUpdateMode mode;
+    @JsonCreator
+    public DmfAttributeUpdate(
+            @JsonProperty("attributes") final Map<String, String> attributes,
+            @JsonProperty("mode") final DmfUpdateMode mode) {
+        this.attributes = attributes == null ? Collections.emptyMap() : attributes;
+        this.mode = mode;
+    }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfAutoConfirmation.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfAutoConfirmation.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -23,10 +24,17 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfAutoConfirmation {
 
-    @JsonProperty
-    private boolean enabled;
-    @JsonProperty
-    private String initiator;
-    @JsonProperty
-    private String remark;
+    private final boolean enabled;
+    private final String initiator;
+    private final String remark;
+
+    @JsonCreator
+    public DmfAutoConfirmation(
+            @JsonProperty("enabled") final boolean enabled,
+            @JsonProperty("initiator") final String initiator,
+            @JsonProperty("remark") final String remark) {
+        this.enabled = enabled;
+        this.initiator = initiator;
+        this.remark = remark;
+    }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfBatchDownloadAndUpdateRequest.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfBatchDownloadAndUpdateRequest.java
@@ -17,78 +17,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
  * JSON representation of batch download and update request.
  */
+@Data
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfBatchDownloadAndUpdateRequest {
 
-    @Getter
-    @Setter
-    @JsonProperty
-    private Long timestamp;
+    private final Long timestamp;
+    private final List<DmfTarget> targets;
+    private final List<DmfSoftwareModule> softwareModules;
 
-    @JsonProperty
-    private List<DmfTarget> targets;
-
-    @JsonProperty
-    private List<DmfSoftwareModule> softwareModules;
-
-    public List<DmfSoftwareModule> getSoftwareModules() {
-        if (softwareModules == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(softwareModules);
-    }
-
-    /**
-     * Add a Software module.
-     *
-     * @param createSoftwareModule the module
-     */
-    public void addSoftwareModule(final DmfSoftwareModule createSoftwareModule) {
-        if (softwareModules == null) {
-            softwareModules = new ArrayList<>();
-        }
-
-        softwareModules.add(createSoftwareModule);
-    }
-
-    public List<DmfTarget> getTargets() {
-        if (targets == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(targets);
-    }
-
-    /**
-     * Add a Target.
-     *
-     * @param target the target
-     */
-    public void addTarget(final DmfTarget target) {
-        if (targets == null) {
-            targets = new ArrayList<>();
-        }
-
-        targets.add(target);
-    }
-
-    /**
-     * Add multiple Targets.
-     *
-     * @param targets the target
-     */
-    public void addTargets(final List<DmfTarget> targets) {
-        if (this.targets == null) {
-            this.targets = new ArrayList<>();
-        }
-        this.targets.addAll(targets);
+    public  DmfBatchDownloadAndUpdateRequest(
+            @JsonProperty("timestamp") final Long timestamp,
+            @JsonProperty("targets") final List<DmfTarget> targets,
+            @JsonProperty("softwareModules") final List<DmfSoftwareModule> softwareModules) {
+        this.timestamp = timestamp;
+        this.targets = targets == null ? Collections.emptyList() : targets;
+        this.softwareModules = softwareModules == null ? Collections.emptyList() : Collections.unmodifiableList(softwareModules);
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfConfirmRequest.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfConfirmRequest.java
@@ -9,33 +9,41 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.ToString;
 
 /**
  * JSON representation of confirm request.
  */
+@Getter
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfConfirmRequest extends DmfActionRequest {
 
-    @Getter
-    @Setter
-    @JsonProperty
-    private String targetSecurityToken;
+    private final String targetSecurityToken;
+    private final List<DmfSoftwareModule> softwareModules;
 
-    @JsonProperty
-    private List<DmfSoftwareModule> softwareModules;
+    @JsonCreator
+    public DmfConfirmRequest(
+            @JsonProperty("actionId") final Long actionId,
+            @JsonProperty("targetSecurityToken") final String targetSecurityToken,
+            @JsonProperty("softwareModules") final List<DmfSoftwareModule> softwareModules) {
+        super(actionId);
+        this.targetSecurityToken = targetSecurityToken;
+        this.softwareModules = softwareModules;
+    }
 
     public List<DmfSoftwareModule> getSoftwareModules() {
         if (softwareModules == null) {
@@ -43,19 +51,5 @@ public class DmfConfirmRequest extends DmfActionRequest {
         }
 
         return Collections.unmodifiableList(softwareModules);
-    }
-
-    /**
-     * Add a Software module.
-     *
-     * @param createSoftwareModule the module
-     */
-    public void addSoftwareModule(final DmfSoftwareModule createSoftwareModule) {
-        if (softwareModules == null) {
-            softwareModules = new ArrayList<>();
-        }
-
-        softwareModules.add(createSoftwareModule);
-
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfCreateThing.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfCreateThing.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -23,12 +24,17 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfCreateThing {
 
-    @JsonProperty
-    private String name;
+    private final String name;
+    private final String type;
+    private final DmfAttributeUpdate attributeUpdate;
 
-    @JsonProperty
-    private String type;
-
-    @JsonProperty
-    private DmfAttributeUpdate attributeUpdate;
+    @JsonCreator
+    public DmfCreateThing(
+            @JsonProperty("name") final String name,
+            @JsonProperty("type") final String type,
+            @JsonProperty("attributeUpdate") final DmfAttributeUpdate attributeUpdate) {
+        this.name = name;
+        this.type = type;
+        this.attributeUpdate = attributeUpdate;
+    }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfDownloadAndUpdateRequest.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfDownloadAndUpdateRequest.java
@@ -13,43 +13,35 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.ToString;
 
 /**
  * JSON representation of download and update request.
  */
+@Getter
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfDownloadAndUpdateRequest extends DmfActionRequest {
 
-    @Setter
-    @Getter
-    @JsonProperty
-    private String targetSecurityToken;
+    private final String targetSecurityToken;
+    private final List<DmfSoftwareModule> softwareModules;
 
-    @JsonProperty
-    private List<DmfSoftwareModule> softwareModules;
-
-    public List<DmfSoftwareModule> getSoftwareModules() {
-        if (softwareModules == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(softwareModules);
-    }
-
-    public void addSoftwareModule(final DmfSoftwareModule createSoftwareModule) {
-        if (softwareModules == null) {
-            softwareModules = new ArrayList<>();
-        }
-
-        softwareModules.add(createSoftwareModule);
+    @JsonCreator
+    public DmfDownloadAndUpdateRequest(
+            @JsonProperty("actionId") final Long actionId,
+            @JsonProperty("targetSecurityToken") final String targetSecurityToken,
+            @JsonProperty("softwareModules") final List<DmfSoftwareModule> softwareModules) {
+        super(actionId);
+        this.targetSecurityToken = targetSecurityToken;
+        this.softwareModules = softwareModules == null ? Collections.emptyList() : Collections.unmodifiableList(softwareModules);
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfMetadata.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfMetadata.java
@@ -24,10 +24,7 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfMetadata {
 
-    @JsonProperty
     private final String key;
-
-    @JsonProperty
     private final String value;
 
     @JsonCreator

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfMultiActionRequest.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfMultiActionRequest.java
@@ -22,18 +22,16 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.eclipse.hawkbit.dmf.amqp.api.EventTopic;
 
 /**
  * JSON representation of a multi-action request.
  */
-@NoArgsConstructor
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfMultiActionRequest {
 
-    private List<DmfMultiActionElement> elements;
+    private final List<DmfMultiActionElement> elements;
 
     @JsonCreator
     public DmfMultiActionRequest(final List<DmfMultiActionElement> elements) {
@@ -45,41 +43,28 @@ public class DmfMultiActionRequest {
         return elements;
     }
 
-    public void addElement(final DmfMultiActionElement element) {
-        if (elements == null) {
-            elements = new ArrayList<>();
-        }
-        elements.add(element);
-    }
-
-    public void addElement(final EventTopic topic, final DmfActionRequest action, final int weight) {
-        final DmfMultiActionElement element = new DmfMultiActionElement();
-        element.setTopic(topic);
-        element.setAction(action);
-        element.setWeight(weight);
-        addElement(element);
-    }
-
     /**
      * Represents an element within a {@link DmfMultiActionRequest}.
      */
     @Data
     public static class DmfMultiActionElement {
 
-        @JsonProperty
-        private EventTopic topic;
+        private final EventTopic topic;
+        private final DmfActionRequest action;
+        private final int weight;
 
-        @JsonProperty
-        private DmfActionRequest action;
-
-        @JsonProperty
-        private int weight;
-
-        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "topic", defaultImpl = DmfActionRequest.class)
-        @JsonSubTypes({ @Type(value = DmfDownloadAndUpdateRequest.class, name = "DOWNLOAD"),
-                @Type(value = DmfDownloadAndUpdateRequest.class, name = "DOWNLOAD_AND_INSTALL") })
-        public void setAction(final DmfActionRequest action) {
+        @JsonCreator
+        public DmfMultiActionElement(
+                @JsonProperty("topic") final EventTopic topic,
+                @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "topic", defaultImpl = DmfActionRequest.class)
+                @JsonSubTypes({
+                        @Type(value = DmfDownloadAndUpdateRequest.class, name = "DOWNLOAD"),
+                        @Type(value = DmfDownloadAndUpdateRequest.class, name = "DOWNLOAD_AND_INSTALL") })
+                @JsonProperty("action") final DmfActionRequest action,
+                @JsonProperty("weight") final int weight) {
+            this.topic = topic;
             this.action = action;
+            this.weight = weight;
         }
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfSoftwareModule.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfSoftwareModule.java
@@ -12,6 +12,7 @@ package org.eclipse.hawkbit.dmf.json.model;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -26,30 +27,26 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfSoftwareModule {
 
-    @JsonProperty
-    private Long moduleId;
-    @JsonProperty
-    private String moduleType;
-    @JsonProperty
-    private String moduleVersion;
-    @JsonProperty
-    private Boolean encrypted;
-    @JsonProperty
-    private List<DmfArtifact> artifacts;
-    @JsonProperty
-    private List<DmfMetadata> metadata;
+    private final Long moduleId;
+    private final String moduleType;
+    private final String moduleVersion;
+    private final Boolean encrypted;
+    private final List<DmfArtifact> artifacts;
+    private final List<DmfMetadata> metadata;
 
-    public List<DmfArtifact> getArtifacts() {
-        if (artifacts == null) {
-            return Collections.emptyList();
-        }
-
-        return Collections.unmodifiableList(artifacts);
-    }
-
-    public void setMetadata(final List<DmfMetadata> metadata) {
-        if (metadata != null && !metadata.isEmpty()) {
-            this.metadata = metadata;
-        }
+    @JsonCreator
+    public DmfSoftwareModule(
+            @JsonProperty("moduleId") final Long moduleId,
+            @JsonProperty("moduleType") final String moduleType,
+            @JsonProperty("moduleVersion") final String moduleVersion,
+            @JsonProperty("encrypted") final Boolean encrypted,
+            @JsonProperty("artifacts") final List<DmfArtifact> artifacts,
+            @JsonProperty("metadata") final List<DmfMetadata> metadata) {
+        this.moduleId = moduleId;
+        this.moduleType = moduleType;
+        this.moduleVersion = moduleVersion;
+        this.encrypted = encrypted;
+        this.artifacts = artifacts == null ? Collections.emptyList() : Collections.unmodifiableList(artifacts);
+        this.metadata = metadata == null || metadata.isEmpty() ? null : metadata;
     }
 }

--- a/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfTarget.java
+++ b/hawkbit-dmf/hawkbit-dmf-api/src/main/java/org/eclipse/hawkbit/dmf/json/model/DmfTarget.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.hawkbit.dmf.json.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -24,11 +25,18 @@ import lombok.ToString;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DmfTarget {
 
-    @JsonProperty
-    private Long actionId;
-    @JsonProperty
-    private String controllerId;
+    private final Long actionId;
+    private final String controllerId;
     @ToString.Exclude
-    @JsonProperty
-    private String targetSecurityToken;
+    private final String targetSecurityToken;
+
+    @JsonCreator
+    public DmfTarget(
+            @JsonProperty("actionId") final Long actionId,
+            @JsonProperty("controllerId") final String controllerId,
+            @JsonProperty("targetSecurityToken") final String targetSecurityToken) {
+        this.actionId = actionId;
+        this.controllerId = controllerId;
+        this.targetSecurityToken = targetSecurityToken;
+    }
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtBaseEntity.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtBaseEntity.java
@@ -9,14 +9,11 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Accessors;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.RepresentationModel;
 
 /**
@@ -28,34 +25,20 @@ import org.springframework.hateoas.RepresentationModel;
 @ToString(callSuper = true)
 public abstract class MgmtBaseEntity extends RepresentationModel<MgmtBaseEntity> {
 
-    @JsonProperty
     @Schema(description = "Entity was originally created by (User, AMQP-Controller, anonymous etc.)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "bumlux")
     private String createdBy;
 
-    @JsonProperty
     @Schema(description = "Entity was originally created at (timestamp UTC in milliseconds)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "1691065905897")
     private Long createdAt;
 
-    @JsonProperty
     @Schema(description = "Entity was last modified by (User, AMQP-Controller, anonymous etc.)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "bumlux")
     private String lastModifiedBy;
 
-    @JsonProperty
     @Schema(description = "Entity was last modified at (timestamp UTC in milliseconds)",
             accessMode = Schema.AccessMode.READ_ONLY, example = "1691065906407")
     @EqualsAndHashCode.Exclude
     private Long lastModifiedAt;
-
-    /**
-     * Added for backwards compatibility
-     *
-     * @return the unique identifier of the {@link MgmtBaseEntity}.
-     */
-    @JsonIgnore
-    public Link getId() {
-        return this.getRequiredLink("self");
-    }
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMaintenanceWindow.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMaintenanceWindow.java
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -34,6 +33,5 @@ public class MgmtMaintenanceWindow extends MgmtMaintenanceWindowRequestBody {
     /**
      * Time in {@link TimeUnit#MILLISECONDS} of the next maintenance window start
      */
-    @JsonProperty
     private long nextStartAt;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMaintenanceWindowRequestBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMaintenanceWindowRequestBody.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -30,17 +29,14 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtMaintenanceWindowRequestBody {
 
-    @JsonProperty
     @Schema(description = """
             Schedule for the maintenance window start in quartz cron notation, such as '0 15 10 * * ? 2018'
             for 10:15am every day during the year 2018""", example = "10 12 14 3 8 ? 2023")
     private String schedule;
 
-    @JsonProperty
     @Schema(description = "Duration of the window, such as '02:00:00' for 2 hours", example = "00:10:00")
     private String duration;
 
-    @JsonProperty
     @Schema(description = "A time-zone offset from Greenwich/UTC, such as '+02:00'", example = "+00:00")
     private String timezone;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMetadata.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMetadata.java
@@ -32,7 +32,6 @@ public class MgmtMetadata {
     @Schema(description = "Metadata property key", example = "someKnownKey")
     private String key;
 
-    @JsonProperty
     @Schema(description = "Metadata property value", example = "someKnownKeyValue")
     private String value;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMetadataBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtMetadataBodyPut.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -28,7 +27,6 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtMetadataBodyPut {
 
-    @JsonProperty
     @Schema(example = "someValue")
     private String value;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtNamedEntity.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtNamedEntity.java
@@ -29,7 +29,6 @@ public abstract class MgmtNamedEntity extends MgmtBaseEntity {
     @Schema(example = "Name of entity")
     private String name;
 
-    @JsonProperty
     @Schema(example = "Description of entity")
     private String description;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtPollStatus.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtPollStatus.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -28,15 +27,12 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtPollStatus {
 
-    @JsonProperty
     @Schema(example = "1691065941102")
     private Long lastRequestAt;
 
-    @JsonProperty
     @Schema(example = "1691109141102")
     private Long nextExpectedRequestAt;
 
-    @JsonProperty
     @Schema(example = "false")
     private boolean overdue;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtTypeEntity.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/MgmtTypeEntity.java
@@ -29,12 +29,10 @@ public abstract class MgmtTypeEntity extends MgmtNamedEntity {
     @Schema(description = "Key that can be interpreted by the target", example = "id.t23")
     private String key;
 
-    @JsonProperty
     @Schema(description = "Colour assigned to the entity that could be used for representation purposes",
             example = "brown")
     private String colour;
 
-    @JsonProperty
     @Schema(description = "Deleted flag, used for soft deleted entities", example = "false")
     private boolean deleted;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/PagedList.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/PagedList.java
@@ -39,12 +39,8 @@ import org.springframework.hateoas.RepresentationModel;
 @JsonInclude(Include.NON_NULL)
 public class PagedList<T> extends RepresentationModel<PagedList<T>> {
 
-    @JsonProperty
     private final List<T> content;
-
-    @JsonProperty
     private final long total;
-
     private final int size;
 
     /**

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtAction.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model.action;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -84,52 +83,33 @@ public class MgmtAction extends MgmtBaseEntity {
      */
     public static final String ACTION_PENDING = "pending";
 
-    @JsonProperty("id")
     @Schema(description = "ID of the action", example = "7")
-    private Long actionId;
-
-    @JsonProperty
+    private Long id;
     @Schema(description = "Type of action", example = "update")
     private String type;
-
-    @JsonProperty
     @Schema(description = "Status of action", example = "finished")
     private String status;
 
-    @JsonProperty
     @Schema(description = "Detailed status of action", example = "finished")
     private String detailStatus;
-
-    @JsonProperty
     @Schema(example = "1691065903238")
     private Long forceTime;
+    private MgmtActionType forceType;
 
-    @JsonProperty(value = "forceType")
-    private MgmtActionType actionType;
-
-    @JsonProperty
     @Schema(description = "Weight of the action showing the importance of the update", example = "600")
     private Integer weight;
-
-    @JsonProperty
     @Schema(hidden = true)
     private MgmtMaintenanceWindow maintenanceWindow;
 
-    @JsonProperty
     @Schema(description = "The ID of the rollout this action was created for", example = "1")
     private Long rollout;
-
-    @JsonProperty
     @Schema(description = "The name of the rollout this action was created for", example = "rollout")
     private String rolloutName;
 
-    @JsonProperty
     @Schema(description = "(Optional) Code provided as part of the last status update that was sent by the device.",
             example = "200")
     private Integer lastStatusCode;
 
-    @JsonProperty
     @Schema(description = "If created by external system this field contains the external reference for the action")
     private String externalRef;
-
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtActionRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtActionRequestBodyPut.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.action;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.ToString;
 import lombok.experimental.Accessors;
@@ -23,6 +22,5 @@ import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
 @ToString
 public class MgmtActionRequestBodyPut {
 
-    @JsonProperty(value = "forceType")
-    private MgmtActionType actionType;
+    private MgmtActionType forceType;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtActionStatus.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/action/MgmtActionStatus.java
@@ -14,7 +14,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -28,26 +27,20 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtActionStatus {
 
-    @JsonProperty("id")
     @Schema(example = "21")
-    private Long statusId;
+    private Long id;
 
-    @JsonProperty
     @Schema(example = "running")
     private String type;
 
-    @JsonProperty
     private List<String> messages;
 
-    @JsonProperty
     @Schema(example = "1691065929524")
     private Long reportedAt;
 
-    @JsonProperty
     @Schema(example = "1691065929524")
     private Long timestamp;
 
-    @JsonProperty
     @Schema(example = "200")
     private Integer code;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/artifact/MgmtArtifact.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/artifact/MgmtArtifact.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model.artifact;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -57,18 +56,14 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtBaseEntity;
         }""")
 public class MgmtArtifact extends MgmtBaseEntity {
 
-    @JsonProperty("id")
     @Schema(description = "Artifact id", example = "3")
-    private Long artifactId;
+    private Long id;
 
-    @JsonProperty
     private MgmtArtifactHash hashes;
 
-    @JsonProperty
     @Schema(example = "file1")
     private String providedFilename;
 
-    @JsonProperty
     @Schema(description = "Size of the artifact", example = "3")
     private Long size;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/artifact/MgmtArtifactHash.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/artifact/MgmtArtifactHash.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.artifact;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,15 +24,10 @@ import lombok.ToString;
 @ToString
 public class MgmtArtifactHash {
 
-    @JsonProperty
     @Schema(description = "SHA1 hash of the artifact", example = "2d86c2a659e364e9abba49ea6ffcd53dd5559f05")
     private String sha1;
-
-    @JsonProperty
     @Schema(description = "MD5 hash of the artifact.", example = "0d1b08c34858921bc7c662b228acb7ba")
     private String md5;
-
-    @JsonProperty
     @Schema(description = "SHA256 hash of the artifact", example = "a03b221c6c6eae7122ca51695d456d5222e524889136394944b2f9763b483615")
     private String sha256;
 

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtActionId.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtActionId.java
@@ -14,7 +14,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -46,18 +45,17 @@ import org.springframework.hateoas.RepresentationModel;
         }""")
 public class MgmtActionId extends RepresentationModel<MgmtActionId> {
 
-    @JsonProperty("id")
     @Schema(description = "ID of the action")
-    private long actionId;
+    private long id;
 
     /**
      * Constructor
      *
-     * @param actionId the actionId
      * @param controllerId the controller Id
+     * @param id the actionId
      */
-    public MgmtActionId(final String controllerId, final long actionId) {
-        this.actionId = actionId;
-        add(linkTo(methodOn(MgmtTargetRestApi.class).getAction(controllerId, actionId)).withSelfRel().expand());
+    public MgmtActionId(final String controllerId, final long id) {
+        this.id = id;
+        add(linkTo(methodOn(MgmtTargetRestApi.class).getAction(controllerId, id)).withSelfRel().expand());
     }
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSet.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSet.java
@@ -133,47 +133,38 @@ import org.eclipse.hawkbit.mgmt.json.model.softwaremodule.MgmtSoftwareModule;
          }""")
 public class MgmtDistributionSet extends MgmtNamedEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "51")
-    private Long dsId;
+    private Long id;
 
-    @JsonProperty
     @Schema(description = "Package version", example = "1.4.2")
     private String version;
 
-    @JsonProperty
     @Schema(description = "The type of the distribution set", example = "test_default_ds_type")
     private String type;
 
-    @JsonProperty
     @Schema(description = "The type name of the distribution set",
             example = "OS (FW) mandatory, runtime (FW) and app (SW) optional")
     private String typeName;
 
-    @JsonProperty
     @Schema(description = """
             True of the distribution set software module setup is complete as defined by the
             distribution set type""", example = "true")
     private Boolean complete;
 
-    @JsonProperty
     @Schema(description = "If the distribution set is locked", example = "true")
     private boolean locked;
 
-    @JsonProperty
     @Schema(description = "Deleted flag, used for soft deleted entities", example = "false")
     private boolean deleted;
 
-    @JsonProperty
     @Schema(description = "True by default and false after the distribution set is invalidated by the user", example = "true")
     private boolean valid;
 
-    @JsonProperty
     @Schema(description = """
             True if DS is a required migration step for another DS. As a result the DS’s assignment will not be cancelled
             when another DS is assigned (note: updatable only if DS is not yet assigned to a target)""", example = "false")
     private boolean requiredMigrationStep;
 
-    @JsonProperty
     private List<MgmtSoftwareModule> modules = new ArrayList<>();
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetRequestBodyPost.java
@@ -14,7 +14,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -34,23 +33,18 @@ import org.eclipse.hawkbit.mgmt.json.model.softwaremodule.MgmtSoftwareModuleAssi
 public class MgmtDistributionSetRequestBodyPost extends MgmtDistributionSetRequestBodyPut {
 
     // deprecated format from the times where os, application and runtime where statically defined
-    @JsonProperty
     @Schema(hidden = true)
     private MgmtSoftwareModuleAssignment os;
 
-    @JsonProperty
     @Schema(hidden = true)
     private MgmtSoftwareModuleAssignment runtime;
 
-    @JsonProperty
     @Schema(hidden = true)
     private MgmtSoftwareModuleAssignment application;
     // deprecated format - END
 
-    @JsonProperty
     private List<MgmtSoftwareModuleAssignment> modules;
 
-    @JsonProperty
     @Schema(description = "The type of the distribution set", example = "test_default_ds_type")
     private String type;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetRequestBodyPut.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model.distributionset;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -26,19 +25,15 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtDistributionSetRequestBodyPut {
 
-    @JsonProperty
     @Schema(description = "The name of the entity", example = "dsOne")
     private String name;
 
-    @JsonProperty
     @Schema(description = "The description of the entity", example = "Description of the distribution set.")
     private String description;
 
-    @JsonProperty
     @Schema(description = "Package version", example = "1.0.0")
     private String version;
 
-    @JsonProperty
     @Schema(description = """
             Should be set only if change of locked state is requested. If put, the distribution set locked flag will be
             set to the requested. Note: unlock (i.e. set this property to false) with extreme care!
@@ -47,7 +42,6 @@ public class MgmtDistributionSetRequestBodyPut {
             example = "true")
     private Boolean locked;
 
-    @JsonProperty
     @Schema(description = """
             True if DS is a required migration step for another DS. As a result the DS’s assignment will not be cancelled
             when another DS is assigned (note: updatable only if DS is not yet assigned to a target)""", example = "false")

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetStatistics.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtDistributionSetStatistics.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -32,13 +31,12 @@ public class MgmtDistributionSetStatistics {
 
     private static final String TOTAL = "total";
 
-    @JsonProperty("actions")
-    private Map<String, Long> totalActionsPerStatus;
+    // totalActionsPerStatus
+    private Map<String, Long> actions;
 
-    @JsonProperty("rollouts")
-    private Map<String, Long> totalRolloutsPerStatus;
+    // totalRolloutsPerStatus
+    private Map<String, Long> rollouts;
 
-    @JsonProperty
     private Long totalAutoAssignments;
 
     public static class Builder {
@@ -71,8 +69,8 @@ public class MgmtDistributionSetStatistics {
 
         public MgmtDistributionSetStatistics build() {
             MgmtDistributionSetStatistics statistics = new MgmtDistributionSetStatistics();
-            statistics.totalActionsPerStatus = calculateTotalWithStatus(totalActionsPerStatus);
-            statistics.totalRolloutsPerStatus = calculateTotalWithStatus(totalRolloutsPerStatus);
+            statistics.actions = calculateTotalWithStatus(totalActionsPerStatus);
+            statistics.rollouts = calculateTotalWithStatus(totalRolloutsPerStatus);
             statistics.totalAutoAssignments = calculateTotalAutoAssignments();
             return statistics;
         }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtInvalidateDistributionSetRequestBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtInvalidateDistributionSetRequestBody.java
@@ -11,7 +11,6 @@ package org.eclipse.hawkbit.mgmt.json.model.distributionset;
 
 import jakarta.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -24,11 +23,9 @@ import lombok.experimental.Accessors;
 public class MgmtInvalidateDistributionSetRequestBody {
 
     @NotNull
-    @JsonProperty
     @Schema(description = "Type of cancelation for actions referring to the given distribution set")
     private MgmtCancelationType actionCancelationType;
 
-    @JsonProperty
     @Schema(description = "Defines if rollouts referring to this distribution set should be canceled", example = "true")
     private boolean cancelRollouts;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtTargetAssignmentResponseBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtTargetAssignmentResponseBody.java
@@ -34,7 +34,7 @@ import org.springframework.hateoas.RepresentationModel;
 public class MgmtTargetAssignmentResponseBody extends RepresentationModel<MgmtTargetAssignmentResponseBody> {
 
     @Schema(description = """
-            Targets that had this distribution set already assigned (in "offline" case this includes
+            Targets that had this distribution already assigned (in "offline" case this includes
             targets that have arbitrary updates running)""")
     private int alreadyAssigned;
 
@@ -44,6 +44,7 @@ public class MgmtTargetAssignmentResponseBody extends RepresentationModel<MgmtTa
     /**
      * @return the count of assigned targets
      */
+    @Schema(description = "Targets that had this distribution set really assigned excluding already assigned")
     @JsonProperty("assigned")
     public int getAssigned() {
         return assignedActions == null ? 0 : assignedActions.size();
@@ -52,6 +53,7 @@ public class MgmtTargetAssignmentResponseBody extends RepresentationModel<MgmtTa
     /**
      * @return the total
      */
+    @Schema(description = "Total targets")
     @JsonProperty("total")
     public int getTotal() {
         return getAssigned() + alreadyAssigned;

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetType.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetType.java
@@ -60,7 +60,7 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtTypeEntity;
         }""")
 public class MgmtDistributionSetType extends MgmtTypeEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "99")
-    private Long moduleId;
+    private Long id;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetTypeRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetTypeRequestBodyPost.java
@@ -36,11 +36,9 @@ public class MgmtDistributionSetTypeRequestBodyPost extends MgmtDistributionSetT
     @Schema(description = "Functional key of the distribution set type", example = "Example key")
     private String key;
 
-    @JsonProperty
     @Schema(description = "Mandatory module type IDs")
     private List<MgmtSoftwareModuleTypeAssignment> mandatorymodules;
 
-    @JsonProperty
     @Schema(description = "Optional module type IDs")
     private List<MgmtSoftwareModuleTypeAssignment> optionalmodules;
 

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetTypeRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionsettype/MgmtDistributionSetTypeRequestBodyPut.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.distributionsettype;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -23,11 +22,9 @@ import lombok.experimental.Accessors;
 @ToString
 public class MgmtDistributionSetTypeRequestBodyPut {
 
-    @JsonProperty
     @Schema(description = "The description of the entity", example = "Example description")
     private String description;
 
-    @JsonProperty
     @Schema(description = "The colour of the entity", example = "rgb(86,37,99)")
     private String colour;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutResponseBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutResponseBody.java
@@ -101,15 +101,15 @@ import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
         }""")
 public class MgmtRolloutResponseBody extends MgmtNamedEntity {
 
+    @JsonProperty(required = true)
+    @Schema(description = "Rollout id", example = "2")
+    private Long id;
+
     @Schema(description = "Target filter query language expression", example = "controllerId==exampleTarget*")
     private String targetFilterQuery;
 
     @Schema(description = "The ID of distribution set of this rollout", example = "2")
     private Long distributionSetId;
-
-    @JsonProperty(value = "id", required = true)
-    @Schema(description = "Rollout id", example = "2")
-    private Long rolloutId;
 
     @JsonProperty(required = true)
     @Schema(description = "The status of this rollout", example = "ready")
@@ -120,43 +120,33 @@ public class MgmtRolloutResponseBody extends MgmtNamedEntity {
     private Long totalTargets;
 
     @Setter(AccessLevel.NONE)
-    @JsonProperty
     @Schema(description = "The total targets per status")
     private Map<String, Long> totalTargetsPerStatus;
 
-    @JsonProperty
     @Schema(description = "The total number of groups created by this rollout", example = "5")
     private Integer totalGroups;
 
-    @JsonProperty
     @Schema(description = "Start at timestamp of Rollout", example = "1691065753136")
     private Long startAt;
 
-    @JsonProperty
     @Schema(description = "Forcetime in milliseconds", example = "1691065762496")
     private Long forcetime;
 
-    @JsonProperty
     @Schema(description = "Deleted flag, used for soft deleted entities", example = "false")
     private boolean deleted;
 
-    @JsonProperty
     @Schema(description = "The type of this rollout")
     private MgmtActionType type;
 
-    @JsonProperty
     @Schema(description = "Weight of the resulting Actions", example = "400")
     private Integer weight;
 
-    @JsonProperty
     @Schema(description = "If this rollout is dynamic or static", example = "true")
     private boolean dynamic;
 
-    @JsonProperty
     @Schema(example = "Approved remark.")
     private String approvalRemark;
 
-    @JsonProperty
     @Schema(example = "exampleUsername")
     private String approveDecidedBy;
 

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutRestRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rollout/MgmtRolloutRestRequestBodyPost.java
@@ -14,7 +14,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -79,19 +78,15 @@ public class MgmtRolloutRestRequestBodyPost extends AbstractMgmtRolloutCondition
     @Schema(description = "Start at timestamp of Rollout", example = "1691065780929")
     private Long startAt;
 
-    @JsonProperty
     @Schema(description = "Weight of the resulting Actions", example = "400")
     private Integer weight;
 
-    @JsonProperty
     @Schema(example = "true")
     private boolean dynamic;
 
-    @JsonProperty
     @Schema(description = "Template for dynamic groups (only if dynamic flag is true)")
     private MgmtDynamicRolloutGroupTemplate dynamicGroupTemplate;
 
-    @JsonProperty
     @Schema(description = """
             (Available with user consent flow active) If the confirmation is required for this rollout. Value will be used
             if confirmation options are missing in the rollout group definitions. Confirmation is required per default""",

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroupResponseBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/rolloutgroup/MgmtRolloutGroupResponseBody.java
@@ -80,14 +80,13 @@ import lombok.experimental.Accessors;
         }""")
 public class MgmtRolloutGroupResponseBody extends MgmtRolloutGroup {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "Rollouts id", example = "63")
-    private Long rolloutGroupId;
+    private Long id;
 
     @Schema(description = "If the rollout group is dynamic", example = "false")
     private boolean dynamic;
 
-    @JsonProperty(required = true)
     @Schema(description = "The status of this rollout", example = "ready")
     private String status;
 

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModule.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModule.java
@@ -67,9 +67,9 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtNamedEntity;
         }""")
 public class MgmtSoftwareModule extends MgmtNamedEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "6")
-    private Long moduleId;
+    private Long id;
 
     @JsonProperty(required = true)
     @Schema(description = "Package version", example = "1.0.0")
@@ -82,19 +82,15 @@ public class MgmtSoftwareModule extends MgmtNamedEntity {
     @Schema(description = "The software module type name of the entity", example = "OS")
     private String typeName;
 
-    @JsonProperty
     @Schema(description = "The software vendor", example = "Vendor Limited, California")
     private String vendor;
 
-    @JsonProperty
     @Schema(description = "If the software module is encrypted", example = "false")
     private boolean encrypted;
 
-    @JsonProperty
     @Schema(description = "If the software module is locked", example = "true")
     private boolean locked;
 
-    @JsonProperty
     @Schema(description = "If the software module is deleted", example = "false")
     private boolean deleted;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleMetadata.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleMetadata.java
@@ -32,12 +32,9 @@ public class MgmtSoftwareModuleMetadata {
     @Schema(description = "Metadata property key", example = "someKnownKey")
     private String key;
 
-    @JsonProperty
     @Schema(description = "Metadata property value", example = "someKnownValue")
     private String value;
 
-    @JsonProperty
-    @Schema(description = "Metadata property is visible to targets as part of software update action",
-            example = "false")
+    @Schema(description = "Metadata property is visible to targets as part of software update action", example = "false")
     private boolean targetVisible;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleMetadataBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleMetadataBodyPut.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model.softwaremodule;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -28,11 +27,9 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtSoftwareModuleMetadataBodyPut {
 
-    @JsonProperty
     @Schema(example = "newValue")
     private String value;
 
-    @JsonProperty
     @Schema(example = "true")
     private Boolean targetVisible;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleRequestBodyPost.java
@@ -35,15 +35,12 @@ public class MgmtSoftwareModuleRequestBodyPost {
     @Schema(example = "os")
     private String type;
 
-    @JsonProperty
     @Schema(example = "SM Description")
     private String description;
 
-    @JsonProperty
     @Schema(example = "Vendor Limited, California")
     private String vendor;
 
-    @JsonProperty
     @Schema(example = "false")
     private boolean encrypted;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremodule/MgmtSoftwareModuleRequestBodyPut.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.softwaremodule;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -23,15 +22,12 @@ import lombok.experimental.Accessors;
 @ToString
 public class MgmtSoftwareModuleRequestBodyPut {
 
-    @JsonProperty
     @Schema(example = "SM Description")
     private String description;
 
-    @JsonProperty
     @Schema(example = "SM Vendor Name")
     private String vendor;
 
-    @JsonProperty
     @Schema(description = """
             Should be set only if change of locked state is requested. If put, the software module locked flag will be
             set to the requested. Note: unlock (i.e. set this property to false) with extreme care!

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleType.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleType.java
@@ -50,11 +50,10 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtTypeEntity;
         }""")
 public class MgmtSoftwareModuleType extends MgmtTypeEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "83")
-    private Long moduleId;
+    private Long id;
 
-    @JsonProperty
     @Schema(description = "Software modules of that type can be assigned at this maximum number " +
             "(e.g. operating system only once)", example = "1")
     private int maxAssignments;

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPost.java
@@ -33,7 +33,6 @@ public class MgmtSoftwareModuleTypeRequestBodyPost extends MgmtSoftwareModuleTyp
     @Schema(example = "Example key")
     private String key;
 
-    @JsonProperty
     @Schema(example = "1")
     private int maxAssignments;
 

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/softwaremoduletype/MgmtSoftwareModuleTypeRequestBodyPut.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.softwaremoduletype;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -23,11 +22,9 @@ import lombok.experimental.Accessors;
 @ToString
 public class MgmtSoftwareModuleTypeRequestBodyPut {
 
-    @JsonProperty
     @Schema(example = "Example description")
     private String description;
 
-    @JsonProperty
     @Schema(example = "rgb(0,0,255")
     private String colour;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemStatisticsRest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemStatisticsRest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -27,21 +26,15 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtSystemStatisticsRest {
 
-    @JsonProperty
     private long overallTargets;
 
-    @JsonProperty
     private long overallArtifacts;
 
-    @JsonProperty
     private long overallArtifactVolumeInBytes;
 
-    @JsonProperty
     private long overallActions;
 
-    @JsonProperty
     private long overallTenants;
 
-    @JsonProperty
     private List<MgmtSystemTenantServiceUsage> tenantStats;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemTenantServiceUsage.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/systemmanagement/MgmtSystemTenantServiceUsage.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.ToString;
 import lombok.experimental.Accessors;
@@ -29,21 +28,15 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtSystemTenantServiceUsage {
 
-    @JsonProperty
     private String tenantName;
 
-    @JsonProperty
     private long targets;
 
-    @JsonProperty
     private long artifacts;
 
-    @JsonProperty
     private long actions;
 
-    @JsonProperty
     private long overallArtifactVolumeInBytes;
 
-    @JsonProperty
     private Map<String, String> usageData;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/tag/MgmtTag.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/tag/MgmtTag.java
@@ -53,11 +53,10 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtNamedEntity;
         }""")
 public class MgmtTag extends MgmtNamedEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "2")
-    private Long tagId;
+    private Long id;
 
-    @JsonProperty
     @Schema(description = "The colour of the entity", example = "red")
     private String colour;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/tag/MgmtTagRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/tag/MgmtTagRequestBodyPut.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.mgmt.json.model.tag;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.ToString;
@@ -28,15 +27,12 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MgmtTagRequestBodyPut {
 
-    @JsonProperty
     @Schema(description = "The name of the entity", example = "Example name")
     private String name;
 
-    @JsonProperty
     @Schema(description = "The description of the entity", example = "Example description")
     private String description;
 
-    @JsonProperty
     @Schema(description = "The colour of the entity", example = "rgb(0,255,0)")
     private String colour;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtDistributionSetAssignment.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtDistributionSetAssignment.java
@@ -26,11 +26,9 @@ public class MgmtDistributionSetAssignment extends MgmtId {
     @Schema(description = "Forcetime in milliseconds", example = "1691065930359")
     private long forcetime;
 
-    @JsonProperty
     @Schema(description = "Importance of the assignment", example = "23")
     private Integer weight;
 
-    @JsonProperty
     @Schema(description = """
             (Available with user consent flow active) Specifies if the confirmation by the device
             is required for this action""", example = "false")

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
@@ -90,52 +90,41 @@ public class MgmtTarget extends MgmtNamedEntity {
     @Schema(description = "Controller ID", example = "123")
     private String controllerId;
 
-    @JsonProperty
     @Schema(description = "If the target is in sync", example = "in_sync")
     private String updateStatus;
 
-    @JsonProperty
     @Schema(description = "Timestamp of the last controller request", example = "1691065941102")
     private Long lastControllerRequestAt;
 
-    @JsonProperty
     @Schema(description = "Install timestamp", example = "1691065941155")
     private Long installedAt;
 
-    @JsonProperty
     @Schema(description = "Last known IP address of the target. Only presented if IP address of the target " +
             "itself is known (connected directly through DDI API)", example = "192.168.0.1")
     private String ipAddress;
 
-    @JsonProperty
     @Schema(description = "The last known address URI of the target. Includes information of the target is " +
             "connected either directly (DDI) through HTTP or indirectly (DMF) through amqp.",
             example = "http://192.168.0.1")
     private String address;
 
-    @JsonProperty
     @Schema(description = "Poll status")
     private MgmtPollStatus pollStatus;
 
-    @JsonProperty
     @Schema(description = "Pre-Shared key that allows targets to authenticate at Direct Device Integration " +
             "API if enabled in the tenant settings", example = "38e6a19932b014040ba061795186514e")
     @ToString.Exclude
     private String securityToken;
 
-    @JsonProperty
     @Schema(description = "Request re-transmission of target attributes", example = "true")
     private boolean requestAttributes;
 
-    @JsonProperty
     @Schema(description = "ID of the target type", example = "19")
     private Long targetType;
 
-    @JsonProperty
     @Schema(description = "Name of the target type", example = "defaultType")
     private String targetTypeName;
 
-    @JsonProperty
     @Schema(description = "Present if user consent flow active. Indicates if auto-confirm is active", example = "false")
     private Boolean autoConfirmActive;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetAutoConfirmUpdate.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetAutoConfirmUpdate.java
@@ -24,11 +24,9 @@ import lombok.experimental.Accessors;
 @ToString
 public class MgmtTargetAutoConfirmUpdate {
 
-    @JsonProperty
     @Schema(description = "(Optional) Initiator set on activation", example = "custom_initiator_value")
     private final String initiator;
 
-    @JsonProperty
     @Schema(description = "(Optional) Remark set on activation", example = "custom_remark")
     private final String remark;
 

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetRequestBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetRequestBody.java
@@ -28,22 +28,18 @@ public class MgmtTargetRequestBody {
     @Schema(description = "Controller ID", example = "123")
     private String controllerId;
 
-    @JsonProperty
     @Schema(description = "The last known address URI of the target. Includes information of the target is " +
             "connected either directly (DDI) through HTTP or indirectly (DMF) through amqp",
             example = "https://192.168.0.1")
     private String address;
 
-    @JsonProperty
     @Schema(description = "Pre-Shared key that allows targets to authenticate at Direct Device Integration API if " +
             "enabled in the tenant settings", example = "2345678DGGDGFTDzztgf")
     private String securityToken;
 
-    @JsonProperty
     @Schema(description = "Request re-transmission of target attributes", example = "true")
     private Boolean requestAttributes;
 
-    @JsonProperty
     @Schema(description = "ID of the target type", example = "10")
     private Long targetType;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targetfilter/MgmtDistributionSetAutoAssignment.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targetfilter/MgmtDistributionSetAutoAssignment.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.mgmt.json.model.targetfilter;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -27,12 +26,9 @@ import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
 @ToString(callSuper = true)
 public class MgmtDistributionSetAutoAssignment extends MgmtId {
 
-    @JsonProperty
     private MgmtActionType type;
 
-    @JsonProperty
     private Integer weight;
 
-    @JsonProperty
     private Boolean confirmationRequired;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targetfilter/MgmtTargetFilterQuery.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targetfilter/MgmtTargetFilterQuery.java
@@ -55,31 +55,25 @@ import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
          }""")
 public class MgmtTargetFilterQuery extends MgmtBaseEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "2")
-    private Long filterId;
+    private Long id;
 
-    @JsonProperty
     @Schema(description = "The name of the entity", example = "filterName")
     private String name;
 
-    @JsonProperty
     @Schema(description = "Target filter query expression", example = "name==*")
     private String query;
 
-    @JsonProperty
     @Schema(example = "15")
     private Long autoAssignDistributionSet;
 
-    @JsonProperty
     @Schema(description = "Auto assign distribution set id")
     private MgmtActionType autoAssignActionType;
 
-    @JsonProperty
     @Schema(description = "Weight of the resulting Actions", example = "600")
     private Integer autoAssignWeight;
 
-    @JsonProperty
     @Schema(description = "(Available with user consent flow active) Defines, if the confirmation is required for an " +
             "action. Confirmation is required per default.", example = "false")
     private Boolean confirmationRequired;

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targettype/MgmtTargetType.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targettype/MgmtTargetType.java
@@ -53,7 +53,7 @@ import org.eclipse.hawkbit.mgmt.json.model.MgmtTypeEntity;
         }""")
 public class MgmtTargetType extends MgmtTypeEntity {
 
-    @JsonProperty(value = "id", required = true)
+    @JsonProperty(required = true)
     @Schema(description = "The technical identifier of the entity", example = "26")
-    private Long typeId;
+    private Long id;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targettype/MgmtTargetTypeRequestBodyPost.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targettype/MgmtTargetTypeRequestBodyPost.java
@@ -11,7 +11,6 @@ package org.eclipse.hawkbit.mgmt.json.model.targettype;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -28,11 +27,9 @@ import org.eclipse.hawkbit.mgmt.json.model.distributionsettype.MgmtDistributionS
 @ToString(callSuper = true)
 public class MgmtTargetTypeRequestBodyPost extends MgmtTargetTypeRequestBodyPut {
 
-    @JsonProperty
     @Schema(description = "Target type key", example = "id.t23")
     private String key;
 
-    @JsonProperty
     @Schema(description = "Array of distribution set types that are compatible to that target type")
     private List<MgmtDistributionSetTypeAssignment> compatibledistributionsettypes;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targettype/MgmtTargetTypeRequestBodyPut.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/targettype/MgmtTargetTypeRequestBodyPut.java
@@ -27,11 +27,9 @@ public class MgmtTargetTypeRequestBodyPut {
     @Schema(description = "The name of the entity", example = "updatedTypeName")
     private String name;
 
-    @JsonProperty
     @Schema(description = "The description of the entity", example = "an updated description")
     private String description;
 
-    @JsonProperty
     @Schema(description = "The colour of the entity", example = "#aaafff")
     private String colour;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetMapper.java
@@ -71,7 +71,7 @@ public final class MgmtDistributionSetMapper {
         final MgmtDistributionSet response = new MgmtDistributionSet();
         MgmtRestModelMapper.mapNamedToNamed(response, distributionSet);
 
-        response.setDsId(distributionSet.getId());
+        response.setId(distributionSet.getId());
         response.setVersion(distributionSet.getVersion());
         response.setComplete(distributionSet.isComplete());
         response.setType(distributionSet.getType().getKey());
@@ -85,14 +85,14 @@ public final class MgmtDistributionSetMapper {
 
         response.setRequiredMigrationStep(distributionSet.isRequiredMigrationStep());
 
-        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getDistributionSet(response.getDsId()))
+        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getDistributionSet(response.getId()))
                 .withSelfRel().expand());
 
         return response;
     }
 
     static void addLinks(final DistributionSet distributionSet, final MgmtDistributionSet response) {
-        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getAssignedSoftwareModules(response.getDsId(),
+        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getAssignedSoftwareModules(response.getId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null))
                 .withRel(MgmtRestConstants.DISTRIBUTIONSET_V1_MODULE).expand());
@@ -100,7 +100,7 @@ public final class MgmtDistributionSetMapper {
         response.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class)
                 .getDistributionSetType(distributionSet.getType().getId())).withRel("type").expand());
 
-        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getMetadata(response.getDsId(),
+        response.add(linkTo(methodOn(MgmtDistributionSetRestApi.class).getMetadata(response.getId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("metadata")
                 .expand());

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetTypeMapper.java
@@ -57,9 +57,9 @@ final class MgmtDistributionSetTypeMapper {
         final MgmtDistributionSetType result = new MgmtDistributionSetType();
 
         MgmtRestModelMapper.mapTypeToType(result, type);
-        result.setModuleId(type.getId());
+        result.setId(type.getId());
 
-        result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getDistributionSetType(result.getModuleId()))
+        result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getDistributionSetType(result.getId()))
                 .withSelfRel().expand());
 
         return result;
@@ -67,10 +67,10 @@ final class MgmtDistributionSetTypeMapper {
 
     static void addLinks(final MgmtDistributionSetType result) {
 
-        result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getMandatoryModules(result.getModuleId()))
+        result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getMandatoryModules(result.getId()))
                 .withRel(MgmtRestConstants.DISTRIBUTIONSETTYPE_V1_MANDATORY_MODULES).expand());
 
-        result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getOptionalModules(result.getModuleId()))
+        result.add(linkTo(methodOn(MgmtDistributionSetTypeRestApi.class).getOptionalModules(result.getId()))
                 .withRel(MgmtRestConstants.DISTRIBUTIONSETTYPE_V1_OPTIONAL_MODULES).expand());
     }
 

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutMapper.java
@@ -78,7 +78,7 @@ final class MgmtRolloutMapper {
         body.setLastModifiedAt(rollout.getLastModifiedAt());
         body.setLastModifiedBy(rollout.getLastModifiedBy());
         body.setName(rollout.getName());
-        body.setRolloutId(rollout.getId());
+        body.setId(rollout.getId());
         body.setDynamic(rollout.isDynamic());
         body.setTargetFilterQuery(rollout.getTargetFilterQuery());
         body.setDistributionSetId(rollout.getDistributionSet().getId());
@@ -217,7 +217,7 @@ final class MgmtRolloutMapper {
         body.setLastModifiedAt(rolloutGroup.getLastModifiedAt());
         body.setLastModifiedBy(rolloutGroup.getLastModifiedBy());
         body.setName(rolloutGroup.getName());
-        body.setRolloutGroupId(rolloutGroup.getId());
+        body.setId(rolloutGroup.getId());
         body.setStatus(rolloutGroup.getStatus().toString().toLowerCase());
         body.setTargetPercentage(rolloutGroup.getTargetPercentage());
         body.setTargetFilterQuery(rolloutGroup.getTargetFilterQuery());

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleMapper.java
@@ -99,7 +99,7 @@ public final class MgmtSoftwareModuleMapper {
 
         final MgmtSoftwareModule response = new MgmtSoftwareModule();
         MgmtRestModelMapper.mapNamedToNamed(response, softwareModule);
-        response.setModuleId(softwareModule.getId());
+        response.setId(softwareModule.getId());
         response.setVersion(softwareModule.getVersion());
         response.setType(softwareModule.getType().getKey());
         response.setTypeName(softwareModule.getType().getName());
@@ -108,21 +108,21 @@ public final class MgmtSoftwareModuleMapper {
         response.setDeleted(softwareModule.isDeleted());
         response.setEncrypted(softwareModule.isEncrypted());
 
-        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getSoftwareModule(response.getModuleId()))
+        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getSoftwareModule(response.getId()))
                 .withSelfRel().expand());
 
         return response;
     }
 
     static void addLinks(final SoftwareModule softwareModule, final MgmtSoftwareModule response) {
-        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getModuleId(), null, null))
+        response.add(linkTo(methodOn(MgmtSoftwareModuleRestApi.class).getArtifacts(response.getId(), null, null))
                 .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_ARTIFACT).expand());
 
         response.add(linkTo(
                 methodOn(MgmtSoftwareModuleTypeRestApi.class).getSoftwareModuleType(softwareModule.getType().getId()))
                 .withRel(MgmtRestConstants.SOFTWAREMODULE_V1_TYPE).expand());
 
-        response.add(linkTo(methodOn(MgmtSoftwareModuleResource.class).getMetadata(response.getModuleId(),
+        response.add(linkTo(methodOn(MgmtSoftwareModuleResource.class).getMetadata(response.getId(),
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET_VALUE,
                 MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT_VALUE, null, null)).withRel("metadata")
                 .expand().expand());
@@ -130,7 +130,7 @@ public final class MgmtSoftwareModuleMapper {
 
     static MgmtArtifact toResponse(final Artifact artifact) {
         final MgmtArtifact artifactRest = new MgmtArtifact();
-        artifactRest.setArtifactId(artifact.getId());
+        artifactRest.setId(artifact.getId());
         artifactRest.setSize(artifact.getSize());
         artifactRest.setHashes(
                 new MgmtArtifactHash(artifact.getSha1Hash(), artifact.getMd5Hash(), artifact.getSha256Hash()));

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleTypeMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleTypeMapper.java
@@ -54,9 +54,9 @@ final class MgmtSoftwareModuleTypeMapper {
 
         MgmtRestModelMapper.mapTypeToType(result, type);
         result.setMaxAssignments(type.getMaxAssignments());
-        result.setModuleId(type.getId());
+        result.setId(type.getId());
 
-        result.add(linkTo(methodOn(MgmtSoftwareModuleTypeRestApi.class).getSoftwareModuleType(result.getModuleId()))
+        result.add(linkTo(methodOn(MgmtSoftwareModuleTypeRestApi.class).getSoftwareModuleType(result.getId()))
                 .withSelfRel().expand());
 
         return result;

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTagMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTagMapper.java
@@ -115,7 +115,7 @@ final class MgmtTagMapper {
 
     private static void mapTag(final MgmtTag response, final Tag tag) {
         MgmtRestModelMapper.mapNamedToNamed(response, tag);
-        response.setTagId(tag.getId());
+        response.setId(tag.getId());
         response.setColour(tag.getColour());
     }
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryMapper.java
@@ -14,7 +14,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -49,7 +48,7 @@ public final class MgmtTargetFilterQueryMapper {
     static MgmtTargetFilterQuery toResponse(final TargetFilterQuery filter, final boolean confirmationFlowEnabled,
             final boolean isRepresentationFull) {
         final MgmtTargetFilterQuery targetRest = new MgmtTargetFilterQuery();
-        targetRest.setFilterId(filter.getId());
+        targetRest.setId(filter.getId());
         targetRest.setName(filter.getName());
         targetRest.setQuery(filter.getQuery());
 
@@ -84,7 +83,7 @@ public final class MgmtTargetFilterQueryMapper {
 
     static void addLinks(final MgmtTargetFilterQuery targetRest) {
         targetRest.add(linkTo(methodOn(MgmtTargetFilterQueryRestApi.class)
-                .postAssignedDistributionSet(targetRest.getFilterId(), null)).withRel("autoAssignDS").expand());
+                .postAssignedDistributionSet(targetRest.getId(), null)).withRel("autoAssignDS").expand());
     }
 
     static TargetFilterQueryCreate fromRequest(final EntityFactory entityFactory, final MgmtTargetFilterQueryRequestBody filterRest) {

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetMapper.java
@@ -224,13 +224,13 @@ public final class MgmtTargetMapper {
     static MgmtAction toResponse(final String targetId, final Action action) {
         final MgmtAction result = new MgmtAction();
 
-        result.setActionId(action.getId());
+        result.setId(action.getId());
         result.setType(getType(action));
         if (ActionType.TIMEFORCED == action.getActionType()) {
             result.setForceTime(action.getForcedTime());
         }
         action.getWeight().ifPresent(result::setWeight);
-        result.setActionType(MgmtRestModelMapper.convertActionType(action.getActionType()));
+        result.setForceType(MgmtRestModelMapper.convertActionType(action.getActionType()));
 
         if (action.isActive()) {
             result.setStatus(MgmtAction.ACTION_PENDING);
@@ -354,7 +354,7 @@ public final class MgmtTargetMapper {
         result.setMessages(messages);
         result.setReportedAt(actionStatus.getCreatedAt());
         result.setTimestamp(actionStatus.getOccurredAt());
-        result.setStatusId(actionStatus.getId());
+        result.setId(actionStatus.getId());
         result.setType(actionStatus.getStatus().name().toLowerCase());
         actionStatus.getCode().ifPresent(result::setCode);
 

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResource.java
@@ -275,7 +275,7 @@ public class MgmtTargetResource implements MgmtTargetRestApi {
             return ResponseEntity.notFound().build();
         }
 
-        if (MgmtActionType.FORCED != actionUpdate.getActionType()) {
+        if (MgmtActionType.FORCED != actionUpdate.getForceType()) {
             throw new ValidationException("Resource supports only switch to FORCED.");
         }
 

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTypeMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetTypeMapper.java
@@ -56,14 +56,14 @@ public final class MgmtTargetTypeMapper {
         final MgmtTargetType result = new MgmtTargetType();
 
         MgmtRestModelMapper.mapTypeToType(result, type);
-        result.setTypeId(type.getId());
+        result.setId(type.getId());
         result.add(
-                linkTo(methodOn(MgmtTargetTypeRestApi.class).getTargetType(result.getTypeId())).withSelfRel().expand());
+                linkTo(methodOn(MgmtTargetTypeRestApi.class).getTargetType(result.getId())).withSelfRel().expand());
         return result;
     }
 
     static void addLinks(final MgmtTargetType result) {
-        result.add(linkTo(methodOn(MgmtTargetTypeRestApi.class).getCompatibleDistributionSets(result.getTypeId()))
+        result.add(linkTo(methodOn(MgmtTargetTypeRestApi.class).getCompatibleDistributionSets(result.getId()))
                 .withRel(MgmtRestConstants.TARGETTYPE_V1_DS_TYPES).expand());
     }
 

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtSoftwareModuleResourceTest.java
@@ -195,7 +195,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
     }
 
     @Test
-    @Description(" Get a single meta data value for a meta data key.")
+    @Description("Get a single meta data value for a meta data key.")
     public void getMetadataValue() throws Exception {
 
         // prepare and create metadata
@@ -205,8 +205,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
         softwareModuleManagement.updateMetaData(
                 entityFactory.softwareModuleMetadata().create(module.getId()).key(knownKey).value(knownValue));
 
-        mvc.perform(
-                        get(MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING + "/{softwareModuleId}/metadata/{metadataKey}",
+        mvc.perform(get(MgmtRestConstants.SOFTWAREMODULE_V1_REQUEST_MAPPING + "/{softwareModuleId}/metadata/{metadataKey}",
                                 module.getId(), knownKey))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
@@ -399,7 +398,7 @@ class MgmtSoftwareModuleResourceTest extends AbstractManagementApiIntegrationTes
         final MgmtArtifact artResult = ResourceUtility.convertArtifactResponse(
                 mvcResult.getResponse().getContentAsString());
         final Long artId = softwareModuleManagement.get(sm.getId()).get().getArtifacts().get(0).getId();
-        assertThat(artResult.getArtifactId()).as("Wrong artifact id").isEqualTo(artId);
+        assertThat(artResult.getId()).as("Wrong artifact id").isEqualTo(artId);
         assertThat((Object)JsonPath.compile("$._links.self.href").read(mvcResult.getResponse().getContentAsString()))
                 .as("Link contains no self url")
                 .hasToString("http://localhost/rest/v1/softwaremodules/" + sm.getId() + "/artifacts/" + artId);

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionUpdatedEvent.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/event/remote/entity/ActionUpdatedEvent.java
@@ -37,5 +37,4 @@ public class ActionUpdatedEvent extends AbstractActionEvent implements EntityUpd
             final Action action, final Long targetId, final Long rolloutId, final Long rolloutGroupId, final String applicationId) {
         super(action, targetId, rolloutId, rolloutGroupId, applicationId);
     }
-
 }

--- a/hawkbit-sdk/hawkbit-sdk-dmf/src/main/java/org/eclipse/hawkbit/sdk/dmf/amqp/DmfSender.java
+++ b/hawkbit-sdk/hawkbit-sdk-dmf/src/main/java/org/eclipse/hawkbit/sdk/dmf/amqp/DmfSender.java
@@ -124,9 +124,7 @@ public class DmfSender {
         messagePropertiesForSP.setContentType(MessageProperties.CONTENT_TYPE_JSON);
         messagePropertiesForSP.setReplyTo(amqpProperties.getSenderForSpExchange());
 
-        final DmfAttributeUpdate attributeUpdate = new DmfAttributeUpdate();
-        attributeUpdate.setMode(mode);
-        attributeUpdate.getAttributes().putAll(attributes);
+        final DmfAttributeUpdate attributeUpdate = new DmfAttributeUpdate(attributes, mode);
 
         sendMessage(DMF_EXCHANGE, convertMessage(attributeUpdate, messagePropertiesForSP));
     }
@@ -161,12 +159,12 @@ public class DmfSender {
             final DmfActionStatus actionStatus, final List<String> updateResultMessages) {
         final MessageProperties messageProperties = new MessageProperties();
         final Map<String, Object> headers = messageProperties.getHeaders();
-        final DmfActionUpdateStatus actionUpdateStatus = new DmfActionUpdateStatus(actionId, actionStatus);
+        final DmfActionUpdateStatus actionUpdateStatus = new DmfActionUpdateStatus(
+                actionId, actionStatus, null, null, updateResultMessages, null);
         headers.put(MessageHeaderKey.TYPE, MessageType.EVENT.name());
         headers.put(MessageHeaderKey.TENANT, tenant);
         headers.put(MessageHeaderKey.TOPIC, EventTopic.UPDATE_ACTION_STATUS.name());
         headers.put(MessageHeaderKey.CONTENT_TYPE, MessageProperties.CONTENT_TYPE_JSON);
-        actionUpdateStatus.addMessage(updateResultMessages);
 
         return convertMessage(actionUpdateStatus, messageProperties);
     }

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/DistributionSetView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/DistributionSetView.java
@@ -63,13 +63,13 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
     public DistributionSetView(final HawkbitMgmtClient hawkbitClient) {
         super(
                 new DistributionSetFilter(hawkbitClient),
-                new SelectionGrid.EntityRepresentation<>(MgmtDistributionSet.class, MgmtDistributionSet::getDsId) {
+                new SelectionGrid.EntityRepresentation<>(MgmtDistributionSet.class, MgmtDistributionSet::getId) {
 
                     private final DistributionSetDetails details = new DistributionSetDetails(hawkbitClient);
 
                     @Override
                     protected void addColumns(Grid<MgmtDistributionSet> grid) {
-                        grid.addColumn(MgmtDistributionSet::getDsId).setHeader(Constants.ID).setAutoWidth(true);
+                        grid.addColumn(MgmtDistributionSet::getId).setHeader(Constants.ID).setAutoWidth(true);
                         grid.addColumn(MgmtDistributionSet::getName).setHeader(Constants.NAME).setAutoWidth(true);
                         grid.addColumn(MgmtDistributionSet::getVersion).setHeader(Constants.VERSION).setAutoWidth(true);
                         grid.addColumn(MgmtDistributionSet::getTypeName).setHeader(Constants.TYPE).setAutoWidth(true);
@@ -87,7 +87,7 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
                 selectionGrid -> {
                     selectionGrid.getSelectedItems().forEach(
                             distributionSet -> hawkbitClient.getDistributionSetRestApi()
-                                    .deleteDistributionSet(distributionSet.getDsId()));
+                                    .deleteDistributionSet(distributionSet.getId()));
                     return CompletableFuture.completedFuture(null);
                 });
     }
@@ -95,11 +95,11 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
     private static SelectionGrid<MgmtSoftwareModule, Long> selectSoftwareModuleGrid() {
         return new SelectionGrid<>(
                 new SelectionGrid.EntityRepresentation<>(
-                        MgmtSoftwareModule.class, MgmtSoftwareModule::getModuleId) {
+                        MgmtSoftwareModule.class, MgmtSoftwareModule::getId) {
 
                     @Override
                     protected void addColumns(Grid<MgmtSoftwareModule> grid) {
-                        grid.addColumn(MgmtSoftwareModule::getModuleId).setHeader(Constants.ID).setAutoWidth(true);
+                        grid.addColumn(MgmtSoftwareModule::getId).setHeader(Constants.ID).setAutoWidth(true);
                         grid.addColumn(MgmtSoftwareModule::getName).setHeader(Constants.NAME).setAutoWidth(true);
                         grid.addColumn(MgmtSoftwareModule::getVersion).setHeader(Constants.VERSION).setAutoWidth(true);
                         grid.addColumn(MgmtSoftwareModule::getTypeName).setHeader(Constants.TYPE).setAutoWidth(true);
@@ -187,7 +187,7 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
             softwareModulesGrid.setItems(query -> Optional.ofNullable(
                     hawkbitClient.getDistributionSetRestApi()
                             .getAssignedSoftwareModules(
-                                    distributionSet.getDsId(),
+                                    distributionSet.getId(),
                                     query.getOffset(), query.getLimit(), Constants.NAME_ASC)
                             .getBody()).stream().flatMap(body -> body.getContent().stream()));
             softwareModulesGrid.setSelectionMode(Grid.SelectionMode.NONE);
@@ -274,7 +274,7 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
                         .flatMap(Collection::stream)
                         .findFirst()
                         .orElseThrow()
-                        .getDsId();
+                        .getId();
                 new AddSoftwareModulesDialog(distributionSetId, hawkbitClient).open();
             });
         }
@@ -308,7 +308,7 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
                         open();
                     }}.result(),
                     v -> {
-                        Utils.remove(softwareModulesGrid.getSelectedItems(), softwareModules, MgmtSoftwareModule::getModuleId);
+                        Utils.remove(softwareModulesGrid.getSelectedItems(), softwareModules, MgmtSoftwareModule::getId);
                         softwareModulesGrid.refreshGrid(false);
                         return CompletableFuture.completedFuture(null);
                     },
@@ -318,7 +318,7 @@ public class DistributionSetView extends TableView<MgmtDistributionSet, Long> {
                 hawkbitClient.getDistributionSetRestApi().assignSoftwareModules(
                         distributionSetId, softwareModules.stream().map(softwareModule -> {
                             final MgmtSoftwareModuleAssignment assignment = new MgmtSoftwareModuleAssignment();
-                            assignment.setId(softwareModule.getModuleId());
+                            assignment.setId(softwareModule.getId());
                             return assignment;
                         }).toList());
                 close();

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/RolloutView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/RolloutView.java
@@ -68,13 +68,13 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
         super(
                 new RolloutFilter(),
                 new SelectionGrid.EntityRepresentation<>(
-                        MgmtRolloutResponseBody.class, MgmtRolloutResponseBody::getRolloutId) {
+                        MgmtRolloutResponseBody.class, MgmtRolloutResponseBody::getId) {
 
                     private final RolloutDetails details = new RolloutDetails(hawkbitClient);
 
                     @Override
                     protected void addColumns(final Grid<MgmtRolloutResponseBody> grid) {
-                        grid.addColumn(MgmtRolloutResponseBody::getRolloutId).setHeader(Constants.ID).setAutoWidth(true);
+                        grid.addColumn(MgmtRolloutResponseBody::getId).setHeader(Constants.ID).setAutoWidth(true);
                         grid.addColumn(MgmtRolloutResponseBody::getName).setHeader(Constants.NAME).setAutoWidth(true);
                         grid.addColumn(MgmtRolloutResponseBody::getTotalGroups).setHeader(Constants.GROUP_COUNT).setAutoWidth(true);
                         grid.addColumn(MgmtRolloutResponseBody::getTotalTargets).setHeader(Constants.TARGET_COUNT).setAutoWidth(true);
@@ -96,7 +96,7 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
                 selectionGrid -> new CreateDialog(hawkbitClient).result(),
                 selectionGrid -> {
                     selectionGrid.getSelectedItems().forEach(
-                            rollout -> hawkbitClient.getRolloutRestApi().delete(rollout.getRolloutId()));
+                            rollout -> hawkbitClient.getRolloutRestApi().delete(rollout.getId()));
                     selectionGrid.refreshGrid(false);
                     return CompletableFuture.completedFuture(null);
                 });
@@ -110,7 +110,7 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
 
         private Actions(final MgmtRolloutResponseBody rollout, final Grid<MgmtRolloutResponseBody> grid,
                 final HawkbitMgmtClient hawkbitClient) {
-            this.rolloutId = rollout.getRolloutId();
+            this.rolloutId = rollout.getId();
             this.grid = grid;
             this.hawkbitClient = hawkbitClient;
             init(rollout);
@@ -120,28 +120,28 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
             if ("READY".equalsIgnoreCase(rollout.getStatus())) {
                 add(Utils.tooltip(new Button(VaadinIcon.START_COG.create()) {{
                     addClickListener(v -> {
-                        hawkbitClient.getRolloutRestApi().start(rollout.getRolloutId());
+                        hawkbitClient.getRolloutRestApi().start(rollout.getId());
                         refresh();
                     });
                 }}, "Start"));
             } else if ("RUNNING".equalsIgnoreCase(rollout.getStatus())) {
                 add(Utils.tooltip(new Button(VaadinIcon.PAUSE.create()) {{
                     addClickListener(v -> {
-                        hawkbitClient.getRolloutRestApi().pause(rollout.getRolloutId());
+                        hawkbitClient.getRolloutRestApi().pause(rollout.getId());
                         refresh();
                     });
                 }}, "Pause"));
             } else if ("PAUSED".equalsIgnoreCase(rollout.getStatus())) {
                 add(Utils.tooltip(new Button(VaadinIcon.START_COG.create()) {{
                     addClickListener(v -> {
-                        hawkbitClient.getRolloutRestApi().resume(rollout.getRolloutId());
+                        hawkbitClient.getRolloutRestApi().resume(rollout.getId());
                         refresh();
                     });
                 }}, "Resume"));
             }
             add(Utils.tooltip(new Button(VaadinIcon.TRASH.create()) {{
                 addClickListener(v -> {
-                    hawkbitClient.getRolloutRestApi().delete(rollout.getRolloutId());
+                    hawkbitClient.getRolloutRestApi().delete(rollout.getId());
                     grid.getDataProvider().refreshAll();
                 });
             }}, "Cancel and Remove"));
@@ -242,7 +242,7 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
             groupGrid.setItems(query -> Optional.ofNullable(
                             hawkbitClient.getRolloutRestApi()
                                     .getRolloutGroups(
-                                            rollout.getRolloutId(),
+                                            rollout.getId(),
                                             query.getOffset(), query.getPageSize(),
                                             null, null, "full")
                                     .getBody())
@@ -254,11 +254,11 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
 
         private static SelectionGrid<MgmtRolloutGroupResponseBody, Long> createGroupGrid() {
             return new SelectionGrid<>(
-                    new SelectionGrid.EntityRepresentation<>(MgmtRolloutGroupResponseBody.class, MgmtRolloutGroupResponseBody::getRolloutGroupId) {
+                    new SelectionGrid.EntityRepresentation<>(MgmtRolloutGroupResponseBody.class, MgmtRolloutGroupResponseBody::getId) {
 
                         @Override
                         protected void addColumns(final Grid<MgmtRolloutGroupResponseBody> grid) {
-                            grid.addColumn(MgmtRolloutGroupResponseBody::getRolloutGroupId).setHeader(Constants.ID).setAutoWidth(true);
+                            grid.addColumn(MgmtRolloutGroupResponseBody::getId).setHeader(Constants.ID).setAutoWidth(true);
                             grid.addColumn(MgmtRolloutGroupResponseBody::getName).setHeader(Constants.NAME).setAutoWidth(true);
                             grid.addColumn(MgmtRolloutGroupResponseBody::getTotalTargets).setHeader(Constants.TARGET_COUNT).setAutoWidth(true);
                             grid.addColumn(MgmtRolloutGroupResponseBody::getTotalTargetsPerStatus).setHeader(Constants.STATS).setAutoWidth(true);
@@ -414,7 +414,7 @@ public class RolloutView extends TableView<MgmtRolloutResponseBody, Long> {
                 close();
                 final MgmtRolloutRestRequestBodyPost request = new MgmtRolloutRestRequestBodyPost();
                 request.setName(name.getValue());
-                request.setDistributionSetId(distributionSet.getValue().getDsId());
+                request.setDistributionSetId(distributionSet.getValue().getId());
                 request.setTargetFilterQuery(targetFilter.getValue().getQuery());
                 request.setDescription(description.getValue());
 

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/SoftwareModuleView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/SoftwareModuleView.java
@@ -75,13 +75,13 @@ public class SoftwareModuleView extends TableView<MgmtSoftwareModule, Long> {
     public SoftwareModuleView(final boolean isParent, final HawkbitMgmtClient hawkbitClient) {
         super(
                 new SoftwareModuleFilter(hawkbitClient),
-                new SelectionGrid.EntityRepresentation<>(MgmtSoftwareModule.class, MgmtSoftwareModule::getModuleId) {
+                new SelectionGrid.EntityRepresentation<>(MgmtSoftwareModule.class, MgmtSoftwareModule::getId) {
 
                     private final SoftwareModuleDetails details = new SoftwareModuleDetails(hawkbitClient);
 
                     @Override
                     protected void addColumns(final Grid<MgmtSoftwareModule> grid) {
-                        grid.addColumn(MgmtSoftwareModule::getModuleId).setHeader(Constants.ID).setAutoWidth(true);
+                        grid.addColumn(MgmtSoftwareModule::getId).setHeader(Constants.ID).setAutoWidth(true);
                         grid.addColumn(MgmtSoftwareModule::getName).setHeader(Constants.NAME).setAutoWidth(true);
                         grid.addColumn(MgmtSoftwareModule::getVersion).setHeader(Constants.VERSION).setAutoWidth(true);
                         grid.addColumn(MgmtSoftwareModule::getTypeName).setHeader(Constants.TYPE).setAutoWidth(true);
@@ -101,7 +101,7 @@ public class SoftwareModuleView extends TableView<MgmtSoftwareModule, Long> {
                 isParent ? v -> new CreateDialog(hawkbitClient).result() : null,
                 isParent ? selectionGrid -> {
                     selectionGrid.getSelectedItems().forEach(
-                            module -> hawkbitClient.getSoftwareModuleRestApi().deleteSoftwareModule(module.getModuleId()));
+                            module -> hawkbitClient.getSoftwareModuleRestApi().deleteSoftwareModule(module.getId()));
                     selectionGrid.refreshGrid(false);
                     return CompletableFuture.completedFuture(null);
                 } : null);
@@ -113,11 +113,11 @@ public class SoftwareModuleView extends TableView<MgmtSoftwareModule, Long> {
 
     private static SelectionGrid<MgmtArtifact, Long> createArtifactGrid() {
         return new SelectionGrid<>(
-                new SelectionGrid.EntityRepresentation<>(MgmtArtifact.class, MgmtArtifact::getArtifactId) {
+                new SelectionGrid.EntityRepresentation<>(MgmtArtifact.class, MgmtArtifact::getId) {
 
                     @Override
                     protected void addColumns(final Grid<MgmtArtifact> grid) {
-                        grid.addColumn(MgmtArtifact::getArtifactId).setHeader(Constants.ID).setAutoWidth(true);
+                        grid.addColumn(MgmtArtifact::getId).setHeader(Constants.ID).setAutoWidth(true);
                         grid.addColumn(MgmtArtifact::getProvidedFilename).setHeader(Constants.NAME).setAutoWidth(true);
                         grid.addColumn(MgmtArtifact::getSize).setHeader("Size").setAutoWidth(true);
                     }
@@ -196,7 +196,7 @@ public class SoftwareModuleView extends TableView<MgmtSoftwareModule, Long> {
             artifactGrid.setItems(query -> Optional.ofNullable(
                             hawkbitClient.getSoftwareModuleRestApi()
                                     .getArtifacts(
-                                            softwareModule.getModuleId(), null, null)
+                                            softwareModule.getId(), null, null)
                                     .getBody())
                     .stream().flatMap(Collection::stream)
                     .skip(query.getOffset())
@@ -280,7 +280,7 @@ public class SoftwareModuleView extends TableView<MgmtSoftwareModule, Long> {
                         .stream().flatMap(Collection::stream)
                         .findFirst()
                         .orElseThrow()
-                        .getModuleId();
+                        .getId();
                 new AddArtifactsDialog(softwareModuleId, hawkbitClient).open();
             });
         }

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
@@ -300,7 +300,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
                         .setName(name.getValue())
                         .setDescription(description.getValue());
                 if (!ObjectUtils.isEmpty(type.getValue())) {
-                    request.setTargetType(type.getValue().getTypeId());
+                    request.setTargetType(type.getValue().getId());
                 }
                 hawkbitClient.getTargetRestApi().createTargets(
                                 List.of(request))


### PR DESCRIPTION
1. Removed @JsonProperty - no value
2. Mix mode with @JsonProperty and no annotation is fixed - only if required = true
3. DDI and AMQP messages are made immutable (via JsonCreator and final fields
4. All fields renamed to match the json properties - so to be consistent
5. getXXXId of the mgmt entities are renamed to getId, getId of the MgmtBaseEntity - removed - self link shall be still available