### PR TITLE
simple-ui: Also show target attributes in Target's view

### DIFF
--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/Constants.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/Constants.java
@@ -26,6 +26,7 @@ public interface Constants {
     String LAST_MODIFIED_BY = "Last modified by";
     String LAST_MODIFIED_AT = "Last modified at";
     String SECURITY_TOKEN = "Security Token";
+    String ATTRIBUTES = "Attributes";
 
     // rollout
     String GROUP_COUNT = "Group Count";


### PR DESCRIPTION
It is useful to see target attributes in the Target's view: for instance SWUpdate can deliver values from the platform which identify some features of it. This can include an arbitrary data, e.g. platform HW revision, component's versions etc.
Thus, add a possibility to see those attributes in the dedicated view.