### PR TITLE
Added Develocity configuration and enabled remote build cache

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -33,6 +33,8 @@ jobs:
           cache: "maven"
 
       - name: Create hawkBit container images
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
         run: |
           mvn clean install -DskipTests && \
           cd docker/docker_build && \

--- a/.github/workflows/verify-hibernate.yml
+++ b/.github/workflows/verify-hibernate.yml
@@ -48,7 +48,11 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Check file license headers
-        run: mvn license:check --batch-mode
+        run: mvn clean license:check --batch-mode
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: Run tests & javadoc
-        run: mvn verify javadoc:javadoc --batch-mode -Djpa.vendor=hibernate -Dlogging.level.org.hibernate.collection.spi.AbstractPersistentCollection=ERROR
+        run: mvn clean verify javadoc:javadoc --batch-mode -Djpa.vendor=hibernate -Dlogging.level.org.hibernate.collection.spi.AbstractPersistentCollection=ERROR
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -48,7 +48,11 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Check file license headers
-        run: mvn license:check --batch-mode
+        run: mvn clean license:check --batch-mode
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: Run tests & javadoc
-        run: mvn verify javadoc:javadoc --batch-mode
+        run: mvn clean verify javadoc:javadoc --batch-mode
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ spring-shell.log
 
 # Documentation
 .gitmodules
+
+# Develocity
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+	* Copyright (c) 2025 Gradle and others
+	*
+	* This program and the accompanying materials are made
+	* available under the terms of the Eclipse Public License 2.0
+	* which is available at https://www.eclipse.org/legal/epl-2.0/
+	*
+	* SPDX-License-Identifier: EPL-2.0
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>iot.hawkbit</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -28,10 +28,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>#{isFalse(env['CI'])}</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <!--
-	* Copyright (c) 2025 Gradle and others
-	*
-	* This program and the accompanying materials are made
-	* available under the terms of the Eclipse Public License 2.0
-	* which is available at https://www.eclipse.org/legal/epl-2.0/
-	*
-	* SPDX-License-Identifier: EPL-2.0
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
 -->
 <develocity
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-	* Copyright (c) 2025 Gradle and others
-	*
-	* This program and the accompanying materials are made
-	* available under the terms of the Eclipse Public License 2.0
-	* which is available at https://www.eclipse.org/legal/epl-2.0/
-	*
-	* SPDX-License-Identifier: EPL-2.0
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
 -->
 <extensions>
 	<extension>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	* Copyright (c) 2025 Gradle and others
+	*
+	* This program and the accompanying materials are made
+	* available under the terms of the Eclipse Public License 2.0
+	* which is available at https://www.eclipse.org/legal/epl-2.0/
+	*
+	* SPDX-License-Identifier: EPL-2.0
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23.1</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -536,6 +536,27 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>develocity-maven-extension</artifactId>
+                    <configuration>
+                        <develocity>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-surefire-plugin</artifactId>
+                                    <outputs>
+                                        <directories>
+                                            <directory>
+                                                <name>allure.results.directory</name>
+                                                <path>${project.build.directory}/allure-results</path>
+                                            </directory>
+                                        </directories>
+                                    </outputs>
+                                </plugin>
+                            </plugins>
+                        </develocity>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue #2306.

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Setting the access key env var was added in relevant CI pipelines, however, the secret will need to be set by Eclipse infra - you can initiate that by opening a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket.

The build scans of the Eclipse Hawkbit project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Hawkbit project and all other Eclipse projects.

On this Develocity instance, the Eclipse Hawkbit project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. In this PR, build caching is enabled, with the local cache being disabled on CI and only allowing CI to write to the remote cache, as per the general recommendations.

I ran [some tests](https://github.com/ribafish/kotlinTests/actions/runs/13587915589) about build speed improvements when caching is configured with the following results:

| Invocation | Build time without cache | Build time with cache | Build time savings |
|-----------|--------------------------|-----------------------|-------------------|
| `install -DskipTests=true` | 2m 42.930s | 58.840s | 1m 44.090s (64%) |
| `verify javadoc:javadoc license:check --batch-mode` | 15m 4.847s | 1m 9.147s | 13m 55.700s(92%) |
| `install` | 14m 49.008s | 1m 3.220s | 13m 45.788s (92%) |

As explained in the [Eclipse Develocity documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration), you can start publishing scans locally if you run the `mvn develocity:provision-access-key` goal, which will take you to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), where you can log in with your eclipse account and confirm access key generation. All the subsequent builds will be published.

Caching can be tested without setting up the Develocity credentials - simply run 2 or more builds (the first one will fill the local cache, next ones can use it).

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**