### PR TITLE
Imrove @Value properties

### DIFF
--- a/hawkbit-ddi/hawkbit-ddi-starter/src/main/java/org/eclipse/hawkbit/autoconfigure/ddi/ControllerSecurityConfiguration.java
+++ b/hawkbit-ddi/hawkbit-ddi-starter/src/main/java/org/eclipse/hawkbit/autoconfigure/ddi/ControllerSecurityConfiguration.java
@@ -94,7 +94,7 @@ class ControllerSecurityConfiguration {
     @Order(301)
     protected SecurityFilterChain filterChainDDI(
             final HttpSecurity http,
-            @Value("${hawkbit.server.security.cors.disableForDdiApi:false}") final boolean disableCorsForDdiApi) throws Exception {
+            @Value("${hawkbit.server.security.cors.disable-for-ddi-api:false}") final boolean disableCorsForDdiApi) throws Exception {
         http
                 .securityMatcher(DDI_ANT_MATCHERS)
                 .csrf(AbstractHttpConfigurer::disable);

--- a/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
+++ b/hawkbit-dmf/hawkbit-dmf-amqp/src/main/java/org/eclipse/hawkbit/amqp/AmqpConfiguration.java
@@ -99,7 +99,7 @@ public class AmqpConfiguration {
     @ConditionalOnMissingBean
     public ErrorHandler errorHandler(
             final List<FatalExceptionStrategy> fatalExceptionStrategies,
-            @Value("${hawkbit.dmf.rabbitmq.fatalExceptionTypes:}") final List<String> fatalExceptionTypes) {
+            @Value("${hawkbit.dmf.rabbitmq.fatal-exception-types:}") final List<String> fatalExceptionTypes) {
         return new ConditionalRejectingErrorHandler(new RequeueExceptionStrategy(fatalExceptionStrategies, fatalExceptionTypes));
     }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/rsql/RsqlConfigHolder.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/rsql/RsqlConfigHolder.java
@@ -29,7 +29,7 @@ public final class RsqlConfigHolder {
      * If RSQL comparison operators shall ignore the case. If ignore case is <code>true</code>
      * "x == ax" will match "x == aX"
      */
-    @Value("${hawkbit.rsql.ignoreCase:true}")
+    @Value("${hawkbit.rsql.ignore-case:true}")
     private boolean ignoreCase;
     /**
      * Declares if the database is case-insensitive, by default assumes <code>false</code>. In case it is case-sensitive and,
@@ -38,7 +38,7 @@ public final class RsqlConfigHolder {
      * If the database is declared as case-sensitive and ignoreCase is set to <code>false</code> the RSQL queries shall use strict
      * syntax - i.e. 'and' instead of 'AND' / 'aND'. Otherwise, the queries would be case-insensitive regarding operators.
      */
-    @Value("${hawkbit.rsql.caseInsensitiveDB:false}")
+    @Value("${hawkbit.rsql.case-insensitive-db:false}")
     private boolean caseInsensitiveDB;
 
     private RsqlVisitorFactory rsqlVisitorFactory;
@@ -52,7 +52,7 @@ public final class RsqlConfigHolder {
      * @deprecated in favour of G2 RSQL visitor. since 0.6.0
      */
     @Deprecated(forRemoval = true, since = "0.6.0")
-    @Value("${hawkbit.rsql.legacyRsqlVisitor:false}")
+    @Value("${hawkbit.rsql.legacy-rsql-visitor:false}")
     private boolean legacyRsqlVisitor;
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa-eclipselink/src/main/java/org/eclipse/hawkbit/repository/jpa/Statistics.java
+++ b/hawkbit-repository/hawkbit-repository-jpa-eclipselink/src/main/java/org/eclipse/hawkbit/repository/jpa/Statistics.java
@@ -42,7 +42,7 @@ import org.springframework.scheduling.annotation.Scheduled;
  * <ol>
  *     <li>The Spring property spring.jpa.properties.eclipselink.profiler=PerformanceMonitor shall be set - enables Eclipselink statistics
  *         collecting</li>
- *     <li>By default the periodic stdout log is disabled by setting hawkbit.jpa.statistics.dumpPeriodMS=9223372036854775807 (Long.MAX_VALUE) -
+ *     <li>By default the periodic stdout log is disabled by setting hawkbit.jpa.statistics.dump-period-ms=9223372036854775807 (Long.MAX_VALUE) -
  *         i.e. effectively <b>never</b>. If log is required it should be set to the required period</li>
  *     <li>The MeterRegistry shall be registered available - e.g. include org.springframework.boot:spring-boot-actuator-autoconfigure</li>
  *     <li>(?) When using in test the metrics MAYBE shall be enabled with @AutoConfigureObservability(tracing = false)</li>
@@ -78,7 +78,7 @@ public class Statistics {
     @Autowired
     public void setEntityManagerFactory(
             final EntityManagerFactory entityManagerFactory,
-            @Value("${hawkbit.jpa.statistics.dumpPeriodMS:9223372036854775807}") final long dumpPeriod) {
+            @Value("${hawkbit.jpa.statistics.dump-period-ms:9223372036854775807}") final long dumpPeriod) {
         this.entityManagerFactory = entityManagerFactory;
         // set stdout log PerformanceMonitor. By default, it is Long.MAX_VALUE (9223372036854775807) which effectively disable logging
         getPerformanceMonitor(entityManagerFactory).setDumpTime(dumpPeriod);

--- a/hawkbit-repository/hawkbit-repository-jpa-hibernate/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa-hibernate/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaConfiguration.java
@@ -40,7 +40,7 @@ public class JpaConfiguration {
 
     protected JpaConfiguration(
             final TenantAware.TenantResolver tenantResolver,
-            @Value("${hibernate.enable_lazy_load_no_trans:true}") final boolean enableLazyLoadNoTrans) {
+            @Value("${hibernate.enable-lazy-load-no-trans:true}") final boolean enableLazyLoadNoTrans) {
         tenantIdentifier = new TenantIdentifier(tenantResolver);
         this.enableLazyLoadNoTrans = enableLazyLoadNoTrans;
     }


### PR DESCRIPTION
Implement recommendation from https://docs.spring.io/spring-boot/reference/features/external-config.html to use kebab case for @Values:

If you do want to use @Value, we recommend that you refer to property names using their canonical form (kebab-case using only lowercase letters). This will allow Spring Boot to use the same logic as it does when relaxed binding @ConfigurationProperties.