### PR TITLE
Extend current SQL translator in EclipseLink

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleManagement.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Repository;
 
 /**
  * Service for managing {@link SoftwareModule}s.

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/SoftwareModuleManagement.java
@@ -36,7 +36,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Repository;
 
 /**
  * Service for managing {@link SoftwareModule}s.

--- a/hawkbit-repository/hawkbit-repository-jpa-eclipselink/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkbitEclipseLinkJpaDialect.java
+++ b/hawkbit-repository/hawkbit-repository-jpa-eclipselink/src/main/java/org/eclipse/hawkbit/repository/jpa/HawkbitEclipseLinkJpaDialect.java
@@ -81,7 +81,7 @@ class HawkbitEclipseLinkJpaDialect extends EclipseLinkJpaDialect {
         return translateJpaSystemExceptionIfPossible(dataAccessException);
     }
 
-    private DataAccessException translateJpaSystemExceptionIfPossible(
+    private static DataAccessException translateJpaSystemExceptionIfPossible(
             final DataAccessException accessException) {
         if (!(accessException instanceof JpaSystemException)) {
             return accessException;
@@ -94,7 +94,7 @@ class HawkbitEclipseLinkJpaDialect extends EclipseLinkJpaDialect {
         return sqlException;
     }
 
-    private DataAccessException searchAndTranslateSqlException(final RuntimeException ex) {
+    private static DataAccessException searchAndTranslateSqlException(final RuntimeException ex) {
         final SQLException sqlException = findSqlException(ex);
         if (sqlException == null) {
             return null;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/aspects/ExceptionMappingAspectHandler.java
@@ -24,7 +24,6 @@ import org.eclipse.hawkbit.repository.exception.ConcurrentModificationException;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.InsufficientPermissionException;
 import org.springframework.core.Ordered;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
@@ -49,12 +48,10 @@ public class ExceptionMappingAspectHandler implements Ordered {
 
     static {
         MAPPED_EXCEPTION_ORDER.add(DuplicateKeyException.class);
-        MAPPED_EXCEPTION_ORDER.add(DataIntegrityViolationException.class);
         MAPPED_EXCEPTION_ORDER.add(OptimisticLockingFailureException.class);
         MAPPED_EXCEPTION_ORDER.add(AccessDeniedException.class);
 
         EXCEPTION_MAPPING.put(DuplicateKeyException.class.getName(), EntityAlreadyExistsException.class.getName());
-        EXCEPTION_MAPPING.put(DataIntegrityViolationException.class.getName(), EntityAlreadyExistsException.class.getName());
 
         EXCEPTION_MAPPING.put(OptimisticLockingFailureException.class.getName(), ConcurrentModificationException.class.getName());
         EXCEPTION_MAPPING.put(AccessDeniedException.class.getName(), InsufficientPermissionException.class.getName());

--- a/hawkbit-rest-core/pom.xml
+++ b/hawkbit-rest-core/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>spring-hateoas</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
         </dependency>

--- a/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/RestConfiguration.java
+++ b/hawkbit-rest-core/src/main/java/org/eclipse/hawkbit/rest/RestConfiguration.java
@@ -33,6 +33,7 @@ import org.eclipse.hawkbit.rest.util.FileStreamingFailedException;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
 import org.springframework.http.HttpStatus;
@@ -270,6 +271,21 @@ public class RestConfiguration {
             }
 
             return new ResponseEntity<>(createExceptionInfo(new MultiPartFileUploadException(responseCause)), HttpStatus.BAD_REQUEST);
+        }
+
+        @ExceptionHandler({DataIntegrityViolationException.class})
+        public ResponseEntity<ExceptionInfo> handleDataAccessException(final HttpServletRequest request, final DataIntegrityViolationException ex) {
+            if (log.isDebugEnabled()) {
+                logRequest(request, ex);
+            } else {
+                log.error("Handling exception {} of request {}", ex.getClass().getName(), request.getRequestURL());
+            }
+
+            final ExceptionInfo response = new ExceptionInfo();
+            response.setMessage("The data provided violates integrity rules. Please ensure all required fields are valid.");
+            response.setExceptionClass(ex.getClass().getName());
+
+            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
         }
 
         private static HttpStatus getStatusOrDefault(final SpServerError error) {


### PR DESCRIPTION
**Problem :** 
Currently SQL exceptions are not properly handled by eclipse link - which sometimes lead to InternalServerError 500 on response - for example if there is a problem with a collation of a field/table/db etc. 
**In the current PR :** 
I switched to a new translator in EclipseLink implementation which provides support for custom exception codes and uses the old translator as a fallback. 
Introduced probably common exception code 1366 (Incorrect String value) to be handled properly. 
Removed DataIntegrityViolationException translation to EntityAlreadyExists in ExceptionMappingAspectHandler which was quite confusing if an sql exception is thrown with code 1366.

