### PR TITLE
SimpleUI: add oauth2 support

### DIFF
--- a/hawkbit-simple-ui/pom.xml
+++ b/hawkbit-simple-ui/pom.xml
@@ -81,6 +81,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/SimpleUIApp.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/SimpleUIApp.java
@@ -9,12 +9,17 @@
  */
 package org.eclipse.hawkbit.ui.simple;
 
-import static feign.Util.ISO_8859_1;
-
 import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.hawkbit.sdk.HawkbitClient;
+import org.eclipse.hawkbit.sdk.HawkbitServer;
+import org.eclipse.hawkbit.sdk.Tenant;
+import org.eclipse.hawkbit.ui.simple.security.OAuth2TokenManager;
+import org.eclipse.hawkbit.ui.simple.view.util.Utils;
 
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
@@ -25,10 +30,6 @@ import feign.RequestInterceptor;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
-import org.eclipse.hawkbit.sdk.HawkbitClient;
-import org.eclipse.hawkbit.sdk.HawkbitServer;
-import org.eclipse.hawkbit.sdk.Tenant;
-import org.eclipse.hawkbit.ui.simple.view.util.Utils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.FeignClientsConfiguration;
@@ -40,18 +41,32 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+
+import static feign.Util.ISO_8859_1;
+import static java.util.Collections.emptyList;
 
 @Theme(themeClass = Lumo.class)
 @PWA(name = "hawkBit UI", shortName = "hawkBit UI")
 @SpringBootApplication
 @Import(FeignClientsConfiguration.class)
 public class SimpleUIApp implements AppShellConfigurator {
-
-    private static final RequestInterceptor AUTHORIZATION = requestTemplate -> {
+    private static final Function<OAuth2TokenManager, RequestInterceptor> AUTHORIZATION = (oAuth2TokenManager) -> requestTemplate -> {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        requestTemplate.header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
-                (Objects.requireNonNull(authentication.getPrincipal(), "User is null!") + ":" + Objects.requireNonNull(
-                        authentication.getCredentials(), "Password is not available!")).getBytes(ISO_8859_1)));
+        if (authentication instanceof OAuth2AuthenticationToken oAuth2AuthenticationToken) {
+            String bearerToken = oAuth2TokenManager.getToken(oAuth2AuthenticationToken);
+            requestTemplate.header("Authorization", "Bearer " + bearerToken);
+        } else {
+            requestTemplate.header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+                    (Objects.requireNonNull(authentication.getPrincipal(), "User is null!") + ":" + Objects.requireNonNull(
+                            authentication.getCredentials(), "Password is not available!")).getBytes(ISO_8859_1)));
+        }
     };
 
     private static final ErrorDecoder DEFAULT_ERROR_DECODER = new ErrorDecoder.Default();
@@ -67,18 +82,43 @@ public class SimpleUIApp implements AppShellConfigurator {
 
     @Bean
     HawkbitClient hawkbitClient(
-            final HawkbitServer hawkBitServer, final Encoder encoder, final Decoder decoder, final Contract contract) {
+            final HawkbitServer hawkBitServer,
+            final Encoder encoder,
+            final Decoder decoder,
+            final Contract contract,
+            final OAuth2TokenManager oAuth2TokenManager
+    ) {
         return new HawkbitClient(
                 hawkBitServer, encoder, decoder, contract,
                 ERROR_DECODER,
                 (tenant, controller) ->
-                        controller == null ?
-                                AUTHORIZATION : HawkbitClient.DEFAULT_REQUEST_INTERCEPTOR_FN.apply(tenant, controller));
+                        controller == null ? AUTHORIZATION.apply(oAuth2TokenManager) : HawkbitClient.DEFAULT_REQUEST_INTERCEPTOR_FN.apply(tenant, controller));
     }
 
     @Bean
     HawkbitMgmtClient hawkbitMgmtClient(final Tenant tenant, final HawkbitClient hawkbitClient) {
         return new HawkbitMgmtClient(tenant, hawkbitClient);
+    }
+
+    @Bean
+    OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService(final HawkbitMgmtClient hawkbitClient) {
+        final OidcUserService delegate = new OidcUserService();
+        return (userRequest) -> {
+            OidcUser oidcUser = delegate.loadUser(userRequest);
+
+            final OAuth2AuthenticationToken tempToken = new OAuth2AuthenticationToken(
+                    oidcUser,
+                    emptyList(),
+                    userRequest.getClientRegistration().getRegistrationId()
+            );
+            final List<SimpleGrantedAuthority> grantedAuthorities =
+                    getGrantedAuthorities(hawkbitClient, tempToken);
+            return new DefaultOidcUser(
+                    grantedAuthorities,
+                    oidcUser.getIdToken(),
+                    oidcUser.getUserInfo()
+            );
+        };
     }
 
     // accepts all user / pass, just delegating them to the feign client
@@ -88,36 +128,8 @@ public class SimpleUIApp implements AppShellConfigurator {
             final String username = authentication.getName();
             final String password = authentication.getCredentials().toString();
 
-            final List<String> roles = new LinkedList<>();
-            roles.add("ANONYMOUS");
-            final SecurityContext unauthorizedContext = SecurityContextHolder.createEmptyContext();
-            unauthorizedContext.setAuthentication(
-                    new UsernamePasswordAuthenticationToken(username, password));
-            final SecurityContext currentContext = SecurityContextHolder.getContext();
-            try {
-                SecurityContextHolder.setContext(unauthorizedContext);
-                if (hawkbitClient.hasSoftwareModulesRead()) {
-                    roles.add("SOFTWARE_MODULE_READ");
-                }
-                if (hawkbitClient.hasRolloutRead()) {
-                    roles.add("ROLLOUT_READ");
-                }
-                if (hawkbitClient.hasDistributionSetRead()) {
-                    roles.add("DISTRIBUTION_SET_READ");
-                }
-                if (hawkbitClient.hasTargetRead()) {
-                    roles.add("TARGET_READ");
-                }
-                if (hawkbitClient.hasConfigRead()) {
-                    roles.add("CONFIG_READ");
-                }
-            } finally {
-                SecurityContextHolder.setContext(currentContext);
-            }
-            return new UsernamePasswordAuthenticationToken(
-                    username, password,
-                    roles.stream().map(role -> new SimpleGrantedAuthority("ROLE_" + role)).toList()) {
-
+            final List<SimpleGrantedAuthority> grantedAuthorities = getGrantedAuthorities(hawkbitClient, new UsernamePasswordAuthenticationToken(username, password));
+            return new UsernamePasswordAuthenticationToken(username, password, grantedAuthorities) {
                 @Override
                 public void eraseCredentials() {
                     // don't erase credentials because they will be used
@@ -125,5 +137,34 @@ public class SimpleUIApp implements AppShellConfigurator {
                 }
             };
         };
+    }
+
+    private List<SimpleGrantedAuthority> getGrantedAuthorities(final HawkbitMgmtClient hawkbitClient, Authentication authentication) {
+        final List<String> roles = new LinkedList<>();
+        roles.add("ANONYMOUS");
+        final SecurityContext unauthorizedContext = SecurityContextHolder.createEmptyContext();
+        unauthorizedContext.setAuthentication(authentication);
+        final SecurityContext currentContext = SecurityContextHolder.getContext();
+        try {
+            SecurityContextHolder.setContext(unauthorizedContext);
+            if (hawkbitClient.hasSoftwareModulesRead()) {
+                roles.add("SOFTWARE_MODULE_READ");
+            }
+            if (hawkbitClient.hasRolloutRead()) {
+                roles.add("ROLLOUT_READ");
+            }
+            if (hawkbitClient.hasDistributionSetRead()) {
+                roles.add("DISTRIBUTION_SET_READ");
+            }
+            if (hawkbitClient.hasTargetRead()) {
+                roles.add("TARGET_READ");
+            }
+            if (hawkbitClient.hasConfigRead()) {
+                roles.add("CONFIG_READ");
+            }
+        } finally {
+            SecurityContextHolder.setContext(currentContext);
+        }
+        return roles.stream().map(role -> new SimpleGrantedAuthority("ROLE_" + role)).toList();
     }
 }

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/OAuth2TokenManager.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/OAuth2TokenManager.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.ui.simple.security;
+
+import java.util.Optional;
+
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2TokenManager {
+    private final OAuth2AuthorizedClientService clientService;
+    private final OAuth2AuthorizedClientManager clientManager;
+
+    OAuth2TokenManager(final OAuth2AuthorizedClientService clientService, final OAuth2AuthorizedClientManager clientManager) {
+        this.clientService = clientService;
+        this.clientManager = clientManager;
+    }
+
+    public String getToken(OAuth2AuthenticationToken authentication) {
+        return Optional.ofNullable(authorizedToken(authentication)).orElse(
+                ((DefaultOidcUser) authentication.getPrincipal()).getIdToken().getTokenValue()
+        );
+    }
+
+    /**
+     * Tries to refresh the id token if it is expired and adds it to the request.
+     */
+    private String authorizedToken(OAuth2AuthenticationToken authentication) {
+        String registrationId = authentication.getAuthorizedClientRegistrationId();
+        OAuth2AuthorizeRequest request = OAuth2AuthorizeRequest.withClientRegistrationId(registrationId).principal(authentication).build();
+
+        // This ensures that there is a client already, otherwise we won't be able to call the manager for authorization
+        OAuth2AuthorizedClient authorizedClient = clientService.loadAuthorizedClient(registrationId, authentication.getName());
+        if (authorizedClient == null) return null;
+
+        // Will ensure that the token is refreshed if needed; do not rely on it being not null as it won't be available
+        // during the first calls made to get the rights and generate the authorities
+        OAuth2AuthorizedClient refreshClient = clientManager.authorize(request);
+        if (refreshClient == null) return null;
+
+        // A small trick to refresh the token if it is expired; the current spring version does not refresh the ID Token when the Access Token is refreshed
+        // This won't be necessary after Spring Security 6.5; cf. https://github.com/spring-projects/spring-security/pull/16589
+        OAuth2AccessToken accessToken = refreshClient.getAccessToken();
+        OAuth2RefreshToken refreshToken = refreshClient.getRefreshToken();
+        ClientRegistration clientRegistration = refreshClient.getClientRegistration();
+        // if this is null, please request it via the scopes
+        if (refreshToken == null) return null;
+
+        OAuth2RefreshTokenGrantRequest refreshTokenGrantRequest = new OAuth2RefreshTokenGrantRequest(clientRegistration, accessToken, refreshToken);
+        OAuth2AccessTokenResponse response = new RestClientRefreshTokenTokenResponseClient().getTokenResponse(refreshTokenGrantRequest);
+        return (String) response.getAdditionalParameters().get("id_token");
+    }
+}

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/Oauth2ClientConfig.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/Oauth2ClientConfig.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.ui.simple.security;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+
+@Configuration
+public class Oauth2ClientConfig {
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(Oauth2ClientConfig.class)
+    Customizer<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurerCustomizer() {
+        return Customizer.withDefaults();
+    }
+}

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/Oauth2ClientConfig.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/Oauth2ClientConfig.java
@@ -9,8 +9,8 @@
  */
 package org.eclipse.hawkbit.ui.simple.security;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -19,10 +19,10 @@ import org.springframework.security.config.annotation.web.configurers.oauth2.cli
 
 @Configuration
 public class Oauth2ClientConfig {
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnBean(Oauth2ClientConfig.class)
-    Customizer<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurerCustomizer() {
+    @Bean(name = "hawkbitOAuth2ClientCustomizer")
+    @ConditionalOnProperty(prefix = "hawkbit.server.security.oauth2.client", name = "enabled")
+    @ConditionalOnMissingBean(name = "hawkbitOAuth2ClientCustomizer")
+    Customizer<OAuth2LoginConfigurer<HttpSecurity>> defaultOAuth2ClientCustomizer() {
         return Customizer.withDefaults();
     }
 }

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/OidcClientProperties.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/OidcClientProperties.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.ui.simple.security;
+
+import lombok.Data;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ToString
+@ConfigurationProperties("hawkbit.server.security")
+public class OidcClientProperties {
+
+    private final OidcClientProperties.Oauth2 oauth2 = new OidcClientProperties.Oauth2();
+
+    @Data
+    public static class Oauth2 {
+
+        private final OidcClientProperties.Oauth2.Client client = new OidcClientProperties.Oauth2.Client();
+
+        @Data
+        public static class Client {
+
+            private boolean enabled = false;
+        }
+    }
+}

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/SecurityConfiguration.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/SecurityConfiguration.java
@@ -11,10 +11,13 @@ package org.eclipse.hawkbit.ui.simple.security;
 
 import com.vaadin.flow.spring.security.VaadinWebSecurity;
 import org.eclipse.hawkbit.ui.simple.view.LoginView;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -22,6 +25,12 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableWebSecurity
 @Configuration
 public class SecurityConfiguration extends VaadinWebSecurity {
+    private Customizer<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurerCustomizer;
+
+    @Autowired(required = false)
+    public void setOAuth2LoginConfigurerCustomizer(final Customizer<OAuth2LoginConfigurer<HttpSecurity>> oauth2LoginConfigurerCustomizer) {
+        this.oAuth2LoginConfigurerCustomizer = oauth2LoginConfigurerCustomizer;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -34,6 +43,11 @@ public class SecurityConfiguration extends VaadinWebSecurity {
                 authorize -> authorize.requestMatchers(new AntPathRequestMatcher("/images/*.png")).permitAll());
 
         super.configure(http);
-        setLoginView(http, LoginView.class);
+
+        if (oAuth2LoginConfigurerCustomizer != null) {
+            http.oauth2Login(oAuth2LoginConfigurerCustomizer);
+        } else {
+            setLoginView(http, LoginView.class);
+        }
     }
 }

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/SecurityConfiguration.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/SecurityConfiguration.java
@@ -12,6 +12,8 @@ package org.eclipse.hawkbit.ui.simple.security;
 import com.vaadin.flow.spring.security.VaadinWebSecurity;
 import org.eclipse.hawkbit.ui.simple.view.LoginView;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -24,11 +26,15 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @EnableWebSecurity
 @Configuration
+@EnableConfigurationProperties({ OidcClientProperties.class })
 public class SecurityConfiguration extends VaadinWebSecurity {
+
     private Customizer<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurerCustomizer;
 
     @Autowired(required = false)
-    public void setOAuth2LoginConfigurerCustomizer(final Customizer<OAuth2LoginConfigurer<HttpSecurity>> oauth2LoginConfigurerCustomizer) {
+    public void setOAuth2LoginConfigurerCustomizer(
+            @Qualifier("hawkbitOAuth2ClientCustomizer") final Customizer<OAuth2LoginConfigurer<HttpSecurity>> oauth2LoginConfigurerCustomizer
+    ) {
         this.oAuth2LoginConfigurerCustomizer = oauth2LoginConfigurerCustomizer;
     }
 


### PR DESCRIPTION
With these changes one can now authenticated on the simple-ui using oauth2.

The rights checks have been mutualized with the basic auth mechanism. 

For example, using azure, one simply has to add the following env environment:
```
HAWKBIT_SERVER_SECURITY_OAUTH2_CLIENT_ENABLED=true

SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_CLIENT_NAME=Login With Azure
SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_PROVIDER=azure
SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_CLIENT_ID=....
SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_CLIENT_SECRET=...
SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_AUTHORIZATION_GRANT_TYPE=...
SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_REDIRECT_URI=...
SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_SCOPE=openid,profile,email
SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_AZURE_ISSUER_URI=....
SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_AZURE_JWK_SET_URI=....
```

# NOTE
~~An important drawback of the way the interceptor is made is that when the token expires there is no simple way to refresh it. As this is used too early and the user is not fully authenticated. Trying to rely on OAuth2AuthorizedClientManager leads nowhere as it wont find the client, hence will be unable to authenticate the request.~~

~~I'll probably open a future PR to update the way we obtain the authorities; this PR at least allows the user to work for 1h :)~~

Edit: it's fixed and is able to refresh the id token now