### PR TITLE
SimpleUI: Add Poll Status and Update Status + improve target filtering

### DIFF
--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
@@ -9,9 +9,29 @@
  */
 package org.eclipse.hawkbit.ui.simple.view;
 
-import com.vaadin.flow.component.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.time.ZoneOffset;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.dependency.Uses;
@@ -29,7 +49,6 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
-import jakarta.annotation.security.RolesAllowed;
 import org.eclipse.hawkbit.mgmt.json.model.MgmtPollStatus;
 import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
 import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtDistributionSet;
@@ -47,14 +66,7 @@ import org.eclipse.hawkbit.ui.simple.view.util.SelectionGrid;
 import org.eclipse.hawkbit.ui.simple.view.util.TableView;
 import org.eclipse.hawkbit.ui.simple.view.util.Utils;
 import org.springframework.util.ObjectUtils;
-
-import java.time.ZoneOffset;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @PageTitle("Targets")
 @Route(value = "targets", layout = MainLayout.class)
@@ -369,7 +381,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
             register.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
             final Button cancel = Utils.tooltip(new Button("Cancel"), "Cancel (Esc)");
             cancel.addClickListener(e -> close());
-            register.addClickShortcut(Key.ESCAPE);
+            cancel.addClickShortcut(Key.ESCAPE);
             getFooter().add(cancel);
             getFooter().add(register);
 
@@ -479,18 +491,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
     }
 
     private static class TargetStatusCell extends HorizontalLayout {
-
-        private final MgmtTarget target;
-        private final TextArea description = new TextArea(Constants.DESCRIPTION);
-        private final TextField createdBy = Utils.textField(Constants.CREATED_BY);
-        private final TextField createdAt = Utils.textField(Constants.CREATED_AT);
-        private final TextField lastModifiedBy = Utils.textField(Constants.LAST_MODIFIED_BY);
-        private final TextField lastModifiedAt = Utils.textField(Constants.LAST_MODIFIED_AT);
-        private final TextField securityToken = Utils.textField(Constants.SECURITY_TOKEN);
-        private final TextArea targetAttributes = new TextArea(Constants.ATTRIBUTES);
-
         private TargetStatusCell(MgmtTarget target) {
-            this.target = target;
             MgmtPollStatus pollStatus = target.getPollStatus();
             String targetUpdateStatus = Optional.ofNullable(target.getUpdateStatus()).orElse("unknown");
             add(pollStatusIconMapper(pollStatus), targetUpdateStatusMapper(targetUpdateStatus));

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/util/Filter.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/util/Filter.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Div;
@@ -46,25 +47,25 @@ public class Filter extends Div {
         filtersDiv.add(primaryRsql.components());
         filtersDiv.addClassName(LumoUtility.Gap.SMALL);
 
-        final Button searchBtn = Utils.tooltip(new Button(VaadinIcon.REFRESH.create()), "Search");
+        final Button searchBtn = Utils.tooltip(new Button(VaadinIcon.SEARCH.create()), "Search (Enter)");
         searchBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         searchBtn.addClickListener(e -> changeListener.accept(rsql.filter()));
-        final Button resetBtn = Utils.tooltip(new Button(VaadinIcon.ERASER.create()), "Reset");
+        searchBtn.addClickShortcut(Key.ENTER);
+        final Button resetBtn = Utils.tooltip(new Button(VaadinIcon.REFRESH.create()), "Reset");
         resetBtn.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
         resetBtn.addClickListener(e -> {
             clear(layout.getChildren());
             changeListener.accept(primaryRsql.filter());
         });
 
-        final Div actionDiv = new Div();
-        actionDiv.add(searchBtn, resetBtn);
-        actionDiv.addClassNames(LumoUtility.Gap.SMALL);
+        final HorizontalLayout actions = new HorizontalLayout(searchBtn, resetBtn);
+        actions.addClassNames(LumoUtility.Gap.SMALL);
 
         layout.setPadding(true);
         layout.setAlignItems(FlexComponent.Alignment.BASELINE);
         layout.add(filtersDiv);
+        layout.add(actions);
 
-        layout.add(actionDiv);
         if (secondaryOptionalRsql != null) {
             final Button toggleBtn = Utils.tooltip(new Button(VaadinIcon.FLIP_V.create()), "Toggle Search");
             toggleBtn.addThemeVariants(ButtonVariant.LUMO_TERTIARY);


### PR DESCRIPTION
Before and after the poll status / update status. I used the same ideas from the previous ui, one minor difference is when no poll status is available I used a "?" rather than "!" which I reserved for overdue
<img width="1720" alt="add_status_column" src="https://github.com/user-attachments/assets/3e3f73f1-e8c5-45ec-a0a9-cbaa16296237" />

Some changes to the Target Filter:
- Used the correct icons: loop for search, refresh for reset + better alignment
- Fixed discrepancy in the padding between the filters
- Added filter update mechanism and made it clear when we're saving vs duplicating a filter

![output](https://github.com/user-attachments/assets/3ba7ddcf-b07b-4aa4-a6e1-18ed5cdd0e98)

