### PR TITLE
simple-ui: add support for side panel vs grid details

### DIFF
--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
@@ -106,9 +106,6 @@ public class TargetView extends TableView<MgmtTarget, String> {
                         grid.addColumn(MgmtTarget::getControllerId).setHeader(CONTROLLER_ID).setAutoWidth(true);
                         grid.addColumn(MgmtTarget::getName).setHeader(Constants.NAME).setAutoWidth(true);
                         grid.addColumn(MgmtTarget::getTargetTypeName).setHeader(Constants.TYPE).setAutoWidth(true);
-
-                        grid.setItemDetailsRenderer(new ComponentRenderer<>(
-                                () -> new TargetDetailedView(hawkbitClient), TargetDetailedView::setItem));
                     }
                 },
                 (query, filter) -> hawkbitClient.getTargetRestApi()
@@ -124,6 +121,11 @@ public class TargetView extends TableView<MgmtTarget, String> {
                     selectionGrid.getSelectedItems().forEach(toDelete ->
                             hawkbitClient.getTargetRestApi().deleteTarget(toDelete.getControllerId()));
                     return CompletableFuture.completedFuture(null);
+                },
+                (target) -> {
+                    var targetDetailedView = new TargetDetailedView(hawkbitClient);
+                    targetDetailedView.setItem(target);
+                    return targetDetailedView;
                 }
         );
 
@@ -317,7 +319,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
         }
     }
 
-    private static class TargetDetailedView extends TabSheet {
+    protected static class TargetDetailedView extends TabSheet {
 
         private final TargetDetails targetDetails;
         private final TargetAssignedInstalled targetAssignedInstalled;
@@ -483,7 +485,6 @@ public class TargetView extends TableView<MgmtTarget, String> {
             tagSelector.setWidthFull();
             tagSelector.setItemLabelGenerator(MgmtTag::getName);
             tagSelector.setClearButtonVisible(true);
-            tagSelector.setItems(fetchAvailableTags());
 
             final HorizontalLayout tagSelectorLayout = new HorizontalLayout(tagSelector, createTagButton);
             tagSelectorLayout.setWidthFull();
@@ -499,6 +500,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
 
         @Override
         protected void onAttach(AttachEvent attachEvent) {
+            tagSelector.setItems(fetchAvailableTags());
             if (changeListener != null) {
                 changeListener.remove();
             }


### PR DESCRIPTION
As discussed in previous PR; this allows to show the details in a side panel. After some testing, having the details on the a side panel on the right is a way nicer experience than having it at the bottom (the close / open button is close to the panel).

Behaviour:
- When an "eye" button is clicked we rely on a provided function to show the details; the button is then converted into a cross
- Clicking on another "eye' button, will replace the content without closing
- The cross closes the panel as expected

Bonus, fix a performance issue introduced in previous PR when showing details, the tags were fetched too early which slowed down the details display.

<img width="1442" alt="Screenshot 2025-06-04 at 12 50 22" src="https://github.com/user-attachments/assets/8d253847-4dc4-4e7b-b41c-d8698697ef26" />
<img width="1443" alt="Screenshot 2025-06-04 at 12 50 53" src="https://github.com/user-attachments/assets/fc0ab54f-1eb1-46f4-a503-76e561a1aae5" />
