### PR TITLE
simple-ui: improve the oidc id token refresh

### DIFF
--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/SimpleUIApp.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/SimpleUIApp.java
@@ -12,7 +12,6 @@ package org.eclipse.hawkbit.ui.simple;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
-import com.vaadin.flow.theme.lumo.Lumo;
 import feign.Contract;
 import feign.RequestInterceptor;
 import feign.codec.Decoder;
@@ -42,6 +41,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
@@ -59,9 +59,9 @@ public class SimpleUIApp implements AppShellConfigurator {
 
     private static final Function<OAuth2TokenManager, RequestInterceptor> AUTHORIZATION = (oAuth2TokenManager) -> requestTemplate -> {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (oAuth2TokenManager != null && authentication instanceof OAuth2AuthenticationToken oAuth2AuthenticationToken) {
-            String bearerToken = oAuth2TokenManager.getToken(oAuth2AuthenticationToken);
-            requestTemplate.header("Authorization", "Bearer " + bearerToken);
+        if (authentication.getPrincipal() instanceof OidcUser) {
+            var token = oAuth2TokenManager.getToken((OAuth2AuthenticationToken) authentication);
+            requestTemplate.header("Authorization", "Bearer " + token);
         } else {
             requestTemplate.header(
                     "Authorization", "Basic " + Base64.getEncoder().encodeToString(
@@ -110,15 +110,29 @@ public class SimpleUIApp implements AppShellConfigurator {
     OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService(final HawkbitMgmtClient hawkbitClient) {
         final OidcUserService delegate = new OidcUserService();
         return (userRequest) -> {
-            OidcUser oidcUser = delegate.loadUser(userRequest);
+            // fetch the previous oidc user to re-use the same granted authorities and avoid too many requests
+            // when the token refreshes (and potential looping, as the refresh will most certainly go through the oidc user service)
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            OidcUser existingUser = authentication != null && authentication.getPrincipal() instanceof OidcUser existing
+                    ? existing
+                    : null;
 
-            final OAuth2AuthenticationToken tempToken = new OAuth2AuthenticationToken(
-                    oidcUser,
-                    emptyList(),
-                    userRequest.getClientRegistration().getRegistrationId()
-            );
-            final List<SimpleGrantedAuthority> grantedAuthorities =
-                    getGrantedAuthorities(hawkbitClient, tempToken);
+            OidcUser oidcUser = delegate.loadUser(userRequest);
+            final List<SimpleGrantedAuthority> grantedAuthorities = new ArrayList<>();
+            if (existingUser == null) {
+                final OAuth2AuthenticationToken tempToken = new OAuth2AuthenticationToken(
+                        oidcUser,
+                        emptyList(),
+                        userRequest.getClientRegistration().getRegistrationId()
+                );
+                grantedAuthorities.addAll(getGrantedAuthorities(hawkbitClient, tempToken));
+            } else {
+                grantedAuthorities.addAll(existingUser.getAuthorities()
+                        .stream()
+                        .map(authority -> new SimpleGrantedAuthority(authority.getAuthority()))
+                        .toList()
+                );
+            }
             return new DefaultOidcUser(
                     grantedAuthorities,
                     oidcUser.getIdToken(),

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/OAuth2TokenManager.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/security/OAuth2TokenManager.java
@@ -15,17 +15,10 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
-import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
-import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
-import org.springframework.security.oauth2.core.OAuth2RefreshToken;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
+import java.time.Instant;
 
 @Component
 @ConditionalOnProperty(prefix = "hawkbit.server.security.oauth2.client", name = "enabled")
@@ -33,7 +26,6 @@ public class OAuth2TokenManager {
 
     private final OAuth2AuthorizedClientService clientService;
     private final OAuth2AuthorizedClientManager clientManager;
-    private final OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> tokenResponseClient;
 
     OAuth2TokenManager(
             final OAuth2AuthorizedClientService clientService,
@@ -41,42 +33,32 @@ public class OAuth2TokenManager {
     ) {
         this.clientService = clientService;
         this.clientManager = clientManager;
-        this.tokenResponseClient = new RestClientRefreshTokenTokenResponseClient();
     }
 
     public String getToken(final OAuth2AuthenticationToken authentication) {
-        return Optional.ofNullable(authorizedToken(authentication)).orElse(
-                ((DefaultOidcUser) authentication.getPrincipal()).getIdToken().getTokenValue()
-        );
+        final var currentToken = ((DefaultOidcUser) authentication.getPrincipal()).getIdToken();
+        if (currentToken.getExpiresAt() == null || currentToken.getExpiresAt().isBefore(Instant.now())) {
+            refreshToken(authentication);
+            return ((DefaultOidcUser) authentication.getPrincipal()).getIdToken().getTokenValue();
+        } else {
+            return currentToken.getTokenValue();
+        }
     }
 
     /**
      * Tries to refresh the id token if it is expired and adds it to the request.
      */
-    private String authorizedToken(final OAuth2AuthenticationToken authentication) {
+    private void refreshToken(final OAuth2AuthenticationToken authentication) {
         String registrationId = authentication.getAuthorizedClientRegistrationId();
-        OAuth2AuthorizeRequest request = OAuth2AuthorizeRequest.withClientRegistrationId(registrationId).principal(authentication).build();
 
         // This ensures that there is a client already, otherwise we won't be able to call the manager for authorization
         OAuth2AuthorizedClient authorizedClient = clientService.loadAuthorizedClient(registrationId, authentication.getName());
-        if (authorizedClient == null) return null;
+        if (authorizedClient == null) return;
 
         // Will ensure that the token is refreshed if needed; do not rely on it being not null as it won't be available
         // during the first calls made to get the rights and generate the authorities
-        OAuth2AuthorizedClient refreshClient = clientManager.authorize(request);
-        if (refreshClient == null) return null;
-
-        // A small trick to refresh the token if it is expired; the current spring version does not refresh the ID Token when the Access Token is refreshed
-        // This won't be necessary after Spring Security 6.5; cf. https://github.com/spring-projects/spring-security/pull/16589
-        OAuth2AccessToken accessToken = refreshClient.getAccessToken();
-        OAuth2RefreshToken refreshToken = refreshClient.getRefreshToken();
-        ClientRegistration clientRegistration = refreshClient.getClientRegistration();
-        // if this is null, please request it via the scopes
-        if (refreshToken == null) return null;
-
-        OAuth2RefreshTokenGrantRequest refreshTokenGrantRequest = new OAuth2RefreshTokenGrantRequest(
-                clientRegistration, accessToken, refreshToken);
-        OAuth2AccessTokenResponse response = tokenResponseClient.getTokenResponse(refreshTokenGrantRequest);
-        return (String) response.getAdditionalParameters().get("id_token");
+        OAuth2AuthorizeRequest request = OAuth2AuthorizeRequest.withClientRegistrationId(registrationId).principal(authentication).build();
+        // since Spring Security 6.5 this will trigger a refresh of the id token
+        clientManager.authorize(request);
     }
 }


### PR DESCRIPTION
After the upgrade to Spring Boot 3.5.x, the authorized client manager will attempt a refresh of the oidc id token.

Sadly, I thought that it would be a simple clean replacement of the previous hackish code. However, it looks like vaadin does not like the SpringContextHolder.setContext() hacks (if you guys have a solution I'm all ears). Here's what happens when the token expires:

- We get to the interceptor, it calls getToken, which detecting that the token expired will call a refresh 
- During the refresh, spring security will try to reload the oidc user, we end up in the OidcUserService bean which is going to try to refresh the user
- In that exact bean, sadly, we tried to fetch the rights of the user , which in turn will call the interceptor, and we loop again!

Unfortunately, i'm unable to make the SpringContextHolder clear and use the temporary context in this situation, regardless of changing the strategy, the interceptor is always using the previous context.

To remediate this, I went with a bandaid, I fetch the previous user and re-use its grants; this works! But it is not the ideal solution :) 

Opening this in Draft, as we'll be testing this during the next few days with our QA.