### PR TITLE
Introduce target grouping

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/TargetFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/TargetFields.java
@@ -29,6 +29,7 @@ public enum TargetFields implements RsqlQueryField {
     UPDATESTATUS("updateStatus"),
     IPADDRESS("address"),
     ATTRIBUTE("controllerAttributes"),
+    TARGETGROUP("targetGroup"),
     ASSIGNEDDS(
             "assignedDistributionSet",
             DistributionSetFields.NAME.getJpaEntityFieldName(), DistributionSetFields.VERSION.getJpaEntityFieldName()),

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTarget.java
@@ -127,4 +127,7 @@ public class MgmtTarget extends MgmtNamedEntity {
 
     @Schema(description = "Present if user consent flow active. Indicates if auto-confirm is active", example = "false")
     private Boolean autoConfirmActive;
+
+    @Schema(description = "Target group", example = "Europe/East")
+    private String group;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetRequestBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtTargetRequestBody.java
@@ -42,4 +42,7 @@ public class MgmtTargetRequestBody {
 
     @Schema(description = "ID of the target type", example = "10")
     private Long targetType;
+
+    @Schema(description = "Target group", example = "Asia")
+    private String group;
 }

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtRestConstants.java
@@ -47,6 +47,10 @@ public final class MgmtRestConstants {
      */
     public static final String TARGETTYPE_V1_REQUEST_MAPPING = BASE_V1_REQUEST_MAPPING + "/targettypes";
     /**
+     * The target group URL mapping rest resource.
+     */
+    public static final String TARGET_GROUP_V1_REQUEST_MAPPING = BASE_V1_REQUEST_MAPPING + "/targetgroups";
+    /**
      * The tag URL mapping rest resource.
      */
     public static final String DISTRIBUTIONSET_TAG_V1_REQUEST_MAPPING = BASE_V1_REQUEST_MAPPING
@@ -163,6 +167,10 @@ public final class MgmtRestConstants {
      */
     public static final String DISTRIBUTIONSET_TAG_DISTRIBUTIONSETS_REQUEST_MAPPING = "/{distributionsetTagId}/assigned";
     /**
+     * Target group URL mapping rest resource
+     */
+    public static final String TARGET_GROUP_TARGETS_REQUEST_MAPPING = "/{targetGroup}/assigned";
+    /**
      * The default offset parameter in case the offset parameter is not present in the request.
      *
      * @see #REQUEST_PARAMETER_PAGING_OFFSET
@@ -233,6 +241,7 @@ public final class MgmtRestConstants {
     public static final String TARGET_TAG_ORDER = "2000";
     public static final String TARGET_TYPE_ORDER = "3000";
     public static final String TARGET_FILTER_ORDER = "4000";
+    public static final String TARGET_GROUP_ORDER = "4500";
     public static final String ACTION_ORDER = "5000";
     public static final String ROLLOUT_ORDER = "6000";
     public static final String DISTRIBUTION_SET_ORDER = "7000";

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtTargetGroupRestApi.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/rest/api/MgmtTargetGroupRestApi.java
@@ -1,0 +1,337 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.mgmt.rest.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.eclipse.hawkbit.mgmt.json.model.PagedList;
+import org.eclipse.hawkbit.mgmt.json.model.target.MgmtTarget;
+import org.eclipse.hawkbit.rest.OpenApi;
+import org.eclipse.hawkbit.rest.json.model.ExceptionInfo;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+import static org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants.TARGET_GROUP_ORDER;
+
+@Tag(
+        name = "Target Groups", description = "REST API for Target Groups operations.",
+        extensions = @Extension(name = OpenApi.X_HAWKBIT, properties = @ExtensionProperty(name = "order", value = TARGET_GROUP_ORDER)))
+public interface MgmtTargetGroupRestApi {
+
+
+    /**
+     * Handles the GET request of retrieving a list of assigned targets for a specific group. Complex grouping (subgroups) not supported here.
+     * For complex grouping use the analogical resource with query parameter for target group.
+     *
+     * @param targetGroup - target group
+     * @param pagingOffsetParam the offset of list of targets for pagination, might not be present in the rest request then default value will
+     *         be applied
+     * @param pagingLimitParam the limit of the paged request, might not be present in the rest request then default value will be applied
+     * @param sortParam the sorting parameter in the request URL, syntax {@code field:direction, field:direction}
+     * @return a list of targets matching the provided group for a defined or default page request with status OK. The response is always paged. In any failure the
+     *         JsonResponseExceptionHandler is handling the response.
+     */
+    @Operation(summary = "Return assigned targets for group",
+            description = "Handles the GET request of retrieving a list of assigned targets for a specific group. Complex grouping (subgroups) not supported here." +
+                    "For complex grouping use the analogical resource with query parameter for target group.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @GetMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_GROUP_TARGETS_REQUEST_MAPPING,
+            produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
+    ResponseEntity<PagedList<MgmtTarget>> getAssignedTargets(
+            @PathVariable
+            @Schema(description = "The target group of the targets")
+            String targetGroup,
+            @RequestParam(
+                    value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET,
+                    defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET)
+            @Schema(description = "The paging offset (default is 0)")
+            int pagingOffsetParam,
+            @RequestParam(
+                    value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT,
+                    defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT)
+            @Schema(description = "The maximum number of entries in a page (default is 50)")
+            int pagingLimitParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false)
+            @Schema(description = """
+                    The query parameter sort allows to define the sort order for the result of a query. A sort criteria
+                    consists of the name of a field and the sort direction (ASC for ascending and DESC descending).
+                    The sequence of the sort criteria (multiple can be used) defines the sort order of the entities
+                    in the result.""")
+            String sortParam
+    );
+
+    /**
+     * Handles the GET request of retrieving a list of assigned targets for a specific group. Complex grouping (subgroups) is supported here.
+     * Group filter could be proper complex group - e.g. Parent/Child or also could be filtered with wildcard for subgroups - Parent/*
+     *
+     * @param groupFilter - An Actual group or group filter - Parent/Child or Parent/*
+     * @param subgroups - If set to {@code true} enables searches with wildcard, proper equals will be used otherwise
+     * @param pagingOffsetParam the offset of list of targets for pagination, might not be present in the rest request then default value will
+     *         be applied
+     * @param pagingLimitParam the limit of the paged request, might not be present in the rest request then default value will be applied
+     * @param sortParam the sorting parameter in the request URL, syntax {@code field:direction, field:direction}
+     * @return a list of targets matching the provided group for a defined or default page request with status OK. The response is always paged. In any failure the
+     *         JsonResponseExceptionHandler is handling the response.
+     */
+    @Operation(summary = "Return assigned targets for group",
+            description = "Handles the GET request of retrieving a list of assigned targets for a specific group. Complex grouping (subgroups) is supported here." +
+                    "Group filter could be proper complex group - e.g. Parent/Child or also could be filtered with wildcard for subgroups - Parent/*")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @GetMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+    ResponseEntity<PagedList<MgmtTarget>> getAssignedTargetsWithSubgroups(
+            @RequestParam(value = "group")
+            @Schema(description = "Target Group or Filter based on target groups. ")
+            String groupFilter,
+            @RequestParam(value = "subgroups", defaultValue = "false")
+            @Schema(description = " Possibility to search for subgroups with wildcard or not - e.g. ParentGroup/*")
+            boolean subgroups,
+            @RequestParam(
+                    value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_OFFSET,
+                    defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_OFFSET)
+            @Schema(description = "The paging offset (default is 0)")
+            int pagingOffsetParam,
+            @RequestParam(
+                    value = MgmtRestConstants.REQUEST_PARAMETER_PAGING_LIMIT,
+                    defaultValue = MgmtRestConstants.REQUEST_PARAMETER_PAGING_DEFAULT_LIMIT)
+            @Schema(description = "The maximum number of entries in a page (default is 50)")
+            int pagingLimitParam,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SORTING, required = false)
+            @Schema(description = """
+                    The query parameter sort allows to define the sort order for the result of a query. A sort criteria
+                    consists of the name of a field and the sort direction (ASC for ascending and DESC descending).
+                    The sequence of the sort criteria (multiple can be used) defines the sort order of the entities
+                    in the result.""")
+            String sortParam
+    );
+
+    /**
+     * Assigns targets to a given group.
+     * For complex groups use analogical method with query parameters.
+     *
+     * @param targetGroup - target group to be assigned
+     * @param controllerIds - list of controllerIds for targets to be assigned
+     *
+     */
+    @Operation(summary = "Assign target(s) to given group",
+            description = "Handles the POST request of target assignment. Already assigned target will be ignored. " +
+                    "For complex groups use analogical method with query parameters.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully assigned"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
+                    "user in another request at the same time. You may retry your modification request."),
+            @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
+                    "supported by the server for this resource."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @PutMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + MgmtRestConstants.TARGET_GROUP_TARGETS_REQUEST_MAPPING)
+    ResponseEntity<Void> assignTargetsToGroup(
+            @PathVariable(value = "targetGroup")
+            @Schema(description = "The target group to be set. Sub-grouping not allowed here, for sub-grouping use the analogical method with query parameter.")
+            String targetGroup,
+            @Schema(description = "List of controller ids to be assigned", example = "[\"controllerId1\", \"controllerId2\"]")
+            @RequestBody List<String> controllerIds
+    );
+
+    /**
+     * Assigns targets to a given group.
+     * Complex (subgroups) are allowed - e.g. Parent/Child
+     *
+     * @param targetGroup - target group to be assigned
+     * @param controllerIds - list of controllerIds for targets to be assigned
+     *
+     */
+    @Operation(summary = "Assign target(s) to given group",
+            description = "Handles the POST request of target assignment. Already assigned target will be ignored. " +
+                    "Subgroups are allowed - e.g. Parent/Child")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully assigned"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
+                    "user in another request at the same time. You may retry your modification request."),
+            @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
+                    "supported by the server for this resource."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @PutMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+    ResponseEntity<Void> assignTargetsToGroupWithSubgroups(
+            @RequestParam("group")
+            @Schema(description = "The target group to be set. Sub-grouping is allowed here - '/' could be used for subgroups")
+            final String targetGroup,
+            @Schema(description = "List of controller ids to be assigned", example = "[\"controllerId1\", \"controllerId2\"]")
+            @RequestBody List<String> controllerIds
+    );
+
+    /**
+     * Unassigns targets from their groups
+     *
+     * @param controllerIds - list of targets to be unassigned
+     */
+    @Operation(summary = "Unassign targets from their target groups",
+            description = "Handles the DELETE request to unassign the given target(s).")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @DeleteMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+    ResponseEntity<Void> unassignTargetsFromGroup(
+            @RequestBody
+            @Schema(description = "List of controller ids to be unassigned from their groups", example = "[\"controllerId1\", \"controllerId2\"]")
+            List<String> controllerIds
+    );
+
+    /**
+     *
+     * @return list of all assigned target groups
+     */
+    @Operation(summary = "Return all assigned target groups",
+            description = "Handles the GET request of retrieving a list of all target groups.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @GetMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING,
+            produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
+    ResponseEntity<List<String>> getTargetGroups();
+
+    /**
+     * Assign single target to a provided target group
+     *
+     * @param controllerId - controllerId of the target
+     * @param targetGroup - target group to be assigned
+     *
+     */
+    @Operation(summary = "Assign single target to provided target group",
+            description = "Handles the GET request of assigning single target to a provided target group" +
+                    "Subgroups are allowed - e.g. Parent/Child")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully assigned"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
+                    "user in another request at the same time. You may retry your modification request."),
+            @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
+                    "supported by the server for this resource."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @PutMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/{controllerId}")
+    ResponseEntity<Void> assignTargetToGroup(
+            @PathVariable
+            @Schema(description = "Target controllerId") final String controllerId,
+            @RequestParam
+            @Schema(description = "The new target group for the update") final String targetGroup);
+
+
+    /**
+     * Assign targets matching a rsql filter to a provided target group
+     * @param targetGroup - target group to be assigned
+     * @param rsqlParam - rsql filter based on Target fields
+     */
+    @Operation(summary = "Assign targets matching a rsql filter to provided target group",
+            description = "Handles the GET request of assigning targets matching a rsql filter to a provided target group" +
+                    "Subgroups are allowed - e.g. Parent/Child")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully assigned"),
+            @ApiResponse(responseCode = "400", description = "Bad Request - e.g. invalid parameters",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionInfo.class))),
+            @ApiResponse(responseCode = "401", description = "The request requires user authentication."),
+            @ApiResponse(responseCode = "403", description = "Insufficient permissions, entity is not allowed to be " +
+                    "changed (i.e. read-only) or data volume restriction applies."),
+            @ApiResponse(responseCode = "405", description = "The http request method is not allowed on the resource."),
+            @ApiResponse(responseCode = "406", description = "In case accept header is specified and not application/json."),
+            @ApiResponse(responseCode = "409", description = "E.g. in case an entity is created or modified by another " +
+                    "user in another request at the same time. You may retry your modification request."),
+            @ApiResponse(responseCode = "415", description = "The request was attempt with a media-type which is not " +
+                    "supported by the server for this resource."),
+            @ApiResponse(responseCode = "429", description = "Too many requests. The server will refuse further attempts " +
+                    "and the client has to wait another second.")
+    })
+    @PutMapping(value = MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING)
+    ResponseEntity<Void> assignTargetsToGroup(
+            @RequestParam
+            @Schema(description = "The target group to be set. Sub-grouping is allowed here - '/' could be used for subgroups")
+            final String targetGroup,
+            @RequestParam(value = MgmtRestConstants.REQUEST_PARAMETER_SEARCH)
+            @Schema(description = """
+                    Query fields based on the Feed Item Query Language (FIQL). See Entity Definitions for
+                    available fields.""")
+            String rsqlParam);
+}

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetGroupResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetGroupResource.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.mgmt.rest.resource;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.hawkbit.mgmt.json.model.PagedList;
+import org.eclipse.hawkbit.mgmt.json.model.target.MgmtTarget;
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetGroupRestApi;
+import org.eclipse.hawkbit.mgmt.rest.resource.mapper.MgmtTargetMapper;
+import org.eclipse.hawkbit.mgmt.rest.resource.util.PagingUtility;
+import org.eclipse.hawkbit.repository.TargetManagement;
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.repository.model.Target;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
+import org.eclipse.hawkbit.utils.TenantConfigHelper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.eclipse.hawkbit.mgmt.rest.resource.util.PagingUtility.sanitizeTargetSortParam;
+
+@Slf4j
+@RestController
+public class MgmtTargetGroupResource implements MgmtTargetGroupRestApi {
+
+    private final TargetManagement targetManagement;
+    private final TenantConfigHelper tenantConfigHelper;
+
+    public MgmtTargetGroupResource(final TargetManagement targetManagement, final SystemSecurityContext systemSecurityContext,
+            final TenantConfigurationManagement tenantConfigurationManagement) {
+        this.targetManagement = targetManagement;
+        this.tenantConfigHelper = TenantConfigHelper.usingContext(systemSecurityContext, tenantConfigurationManagement);
+    }
+
+    @Override
+    public ResponseEntity<PagedList<MgmtTarget>> getAssignedTargets(String targetGroup, int pagingOffsetParam, int pagingLimitParam, String sortParam) {
+        final Pageable pageable = PagingUtility.toPageable(pagingOffsetParam, pagingLimitParam, sanitizeTargetSortParam(sortParam));
+
+        final Page<Target> targets = targetManagement.findTargetsByGroup(targetGroup, pageable);
+
+        final List<MgmtTarget> rest = MgmtTargetMapper.toResponse(targets.getContent(), tenantConfigHelper);
+        return ResponseEntity.ok(new PagedList<>(rest, targets.getTotalElements()));
+    }
+
+    @Override
+    public ResponseEntity<PagedList<MgmtTarget>> getAssignedTargetsWithSubgroups(String groupFilter, boolean subgroups, int pagingOffsetParam, int pagingLimitParam, String sortParam) {
+        final Pageable pageable = PagingUtility.toPageable(pagingOffsetParam, pagingLimitParam, sanitizeTargetSortParam(sortParam));
+
+        Page<Target> targets;
+        if (subgroups) {
+            String groupFilterRegex = "^[^*%]*\\*?$";
+            Matcher matcher = Pattern.compile(groupFilterRegex).matcher(groupFilter);
+            if (!matcher.matches()) {
+                log.error("Provided group filter {} contains wildcard in different place than in the end", groupFilter);
+                return ResponseEntity.badRequest().build();
+            }
+            groupFilter = groupFilter.replace("*", "%");
+
+            targets = targetManagement.findTargetsByGroupFilter(groupFilter, pageable);
+        } else {
+            targets = targetManagement.findTargetsByGroup(groupFilter, pageable);
+        }
+
+        final List<MgmtTarget> rest = MgmtTargetMapper.toResponse(targets.getContent(), tenantConfigHelper);
+        return ResponseEntity.ok(new PagedList<>(rest, targets.getTotalElements()));
+    }
+
+    @Override
+    public ResponseEntity<Void> assignTargetsToGroup(String targetGroup, List<String> controllerIds) {
+        targetManagement.updateTargetsWithGroup(targetGroup, controllerIds);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> assignTargetsToGroupWithSubgroups(String targetGroup, List<String> controllerIds) {
+        targetManagement.updateTargetsWithGroup(targetGroup, controllerIds);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> unassignTargetsFromGroup(List<String> controllerIds) {
+        targetManagement.updateTargetsWithGroup(null, controllerIds);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<List<String>> getTargetGroups() {
+        final List<String> groups = targetManagement.findGroups();
+        return ResponseEntity.ok(groups);
+    }
+
+    @Override
+    public ResponseEntity<Void> assignTargetToGroup(String controllerId, String targetGroup) {
+
+        log.info("Updating target group invoked...");
+        targetManagement.updateTargetGroup(controllerId, targetGroup);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> assignTargetsToGroup(final String targetGroup, final String rsql) {
+        targetManagement.updateTargetGroupsWithRsql(targetGroup, rsql);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtTargetMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtTargetMapper.java
@@ -140,6 +140,7 @@ public final class MgmtTargetMapper {
         targetRest.setDescription(target.getDescription());
         targetRest.setName(target.getName());
         targetRest.setUpdateStatus(target.getUpdateStatus().name().toLowerCase());
+        targetRest.setGroup(target.getTargetGroup());
 
         final URI address = target.getAddress();
         if (address != null) {
@@ -325,7 +326,7 @@ public final class MgmtTargetMapper {
     private static TargetCreate fromRequest(final EntityFactory entityFactory, final MgmtTargetRequestBody targetRest) {
         return entityFactory.target().create().controllerId(targetRest.getControllerId()).name(targetRest.getName())
                 .description(targetRest.getDescription()).securityToken(targetRest.getSecurityToken())
-                .address(targetRest.getAddress()).targetType(targetRest.getTargetType());
+                .address(targetRest.getAddress()).targetType(targetRest.getTargetType()).targetGroup(targetRest.getGroup());
     }
 
     private static String getType(final Action action) {

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetGroupResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetGroupResourceTest.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.mgmt.rest.resource;
+
+import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
+import org.eclipse.hawkbit.rest.util.JsonBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+public class MgmtTargetGroupResourceTest extends AbstractManagementApiIntegrationTest {
+
+
+    @Test
+    void shouldRetrieveDistinctTargetGroups() throws Exception {
+
+        final List<String> expectedGroups = List.of("Europe", "Asia");
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2").targetGroup("Asia"));
+        targetManagement.create(entityFactory.target().create().controllerId("target3").targetGroup("Europe"));
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0]", Matchers.in(expectedGroups)))
+                .andExpect(jsonPath("$.[1]", Matchers.in(expectedGroups)));
+    }
+
+    @Test
+    void shouldRetrieveTargetsFilteredByGroupAndParentGroupCorrectly() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe/West"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2").targetGroup("Europe/East"));
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                .param("group", "Europe/East")
+                .param("subgroups", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(1)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target2")));
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .param("group", "Europe/*")
+                        .param("subgroups", "true")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(2)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")))
+                .andExpect(jsonPath("content.[1].controllerId", Matchers.equalTo("target2")));
+    }
+
+    @Test
+    void shouldGetBadRequestIfGroupingFilterIsNotCorrect() throws Exception {
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .param("group", "*/East")
+                        .param("subgroups", "true"))
+                .andExpect(status().isBadRequest());
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .param("group", "Europe/%") // % is banned
+                        .param("subgroups", "true"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldGetAssignedTargetsToSpecificGroup() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2").targetGroup("US"));
+        targetManagement.create(entityFactory.target().create().controllerId("target3").targetGroup("Europe"));
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/Europe/assigned")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(2)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")))
+                .andExpect(jsonPath("content.[1].controllerId", Matchers.equalTo("target3")));
+    }
+
+    @Test
+    void shouldAssignListOfTargetsToASpecificGroup() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2"));
+        targetManagement.create(entityFactory.target().create().controllerId("target3").targetGroup("Europe"));
+
+        mvc.perform(put(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/newGroup/assigned")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonBuilder.toArray(Arrays.asList("target1", "target2", "target3"))))
+                .andExpect(status().isOk());
+
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/newGroup/assigned")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(3)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")))
+                .andExpect(jsonPath("content.[1].controllerId", Matchers.equalTo("target2")))
+                .andExpect(jsonPath("content.[2].controllerId", Matchers.equalTo("target3")));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenProvidingAnEmptyListOfControllerIds() throws Exception {
+        mvc.perform(put(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/someGroup/assigned")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonBuilder.toArray(Collections.emptyList())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldAssignListOfTargetsToProvidedGroupWithSubgroup() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2"));
+        targetManagement.create(entityFactory.target().create().controllerId("target3").targetGroup("US"));
+
+        mvc.perform(put(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonBuilder.toArray(Arrays.asList("target1", "target2", "target3")))
+                        .param("group", "Europe/East"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
+                        .param("group", "Europe/East")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(3)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")))
+                .andExpect(jsonPath("content.[1].controllerId", Matchers.equalTo("target2")))
+                .andExpect(jsonPath("content.[2].controllerId", Matchers.equalTo("target3")));
+
+        // expect bad request if empty controllerIds
+        mvc.perform(put(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonBuilder.toArray(Collections.emptyList()))
+                        .param("group", "doesNotMatter"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldUnassignTargetsFromGroup() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2").targetGroup("Europe"));
+
+        mvc.perform(delete(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonBuilder.toArray(Arrays.asList("target1", "target2"))))
+                .andExpect(status().isOk());
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
+                        .param("group", "Europe")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(0)));
+
+        // expect bad request if empty
+        mvc.perform(delete(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonBuilder.toArray(Collections.emptyList())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldUpdateSingleTargetGroup() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+
+        mvc.perform(put(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/target1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("group", "Asia"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/asia/assigned")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(1)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")));
+    }
+
+    @Test
+    void shouldUpdateTargetGroupsOfTargetsMatchingTheRsqlFilter() throws Exception {
+        targetManagement.create(entityFactory.target().create().controllerId("target1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target2").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("target3").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("shouldNotBeUpdated1").targetGroup("Europe"));
+        targetManagement.create(entityFactory.target().create().controllerId("shouldNotBeUpdated2").targetGroup("Europe"));
+
+        mvc.perform(put(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("group", "Europe/East")
+                        .param("q", "controllerId==target*"))
+                .andExpect(status().isOk());
+
+        mvc.perform(get(MgmtRestConstants.TARGET_GROUP_V1_REQUEST_MAPPING + "/assigned")
+                        .param("group", "Europe/East")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(3)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")))
+                .andExpect(jsonPath("content.[1].controllerId", Matchers.equalTo("target2")))
+                .andExpect(jsonPath("content.[2].controllerId", Matchers.equalTo("target3")));
+
+
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -602,6 +602,61 @@ public interface TargetManagement {
     Target assignType(@NotEmpty String controllerId, @NotNull Long targetTypeId);
 
     /**
+     * Updates the target group of given {@link Target}.
+     *
+     * @param controllerId to be updated
+     * @param targetGroup - to be assigned to target
+     * @return updated target
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET)
+    void updateTargetGroup(@NotEmpty String controllerId, @NotNull String targetGroup);
+
+    /**
+     * Find targets associated with the provided group - direct eq operation
+     *
+     * @param targetGroup to be filtered for
+     * @param pageable page parameter
+     * @return targets associated with provided targetGroup
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    Page<Target> findTargetsByGroup(@NotEmpty String targetGroup, @NotNull Pageable pageable);
+
+    /**
+     * Find targets by provided group "filter". Which basically translates to a sql like operation
+     *
+     * @param groupFilter filter for target group based on sql like
+     * @param pageable page param
+     * @return targets associated with provided group filter
+     */
+    Page<Target> findTargetsByGroupFilter(@NotEmpty String groupFilter, @NotNull Pageable pageable);
+
+    /**
+     * Finds all the distinct target groups in the scope of a tenant
+     *
+     * @return list of all distinct target groups
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    List<String> findGroups();
+
+    /**
+     * Update the target group of the targets matching the provided rsql filter.
+     *
+     * @param group target group parameter
+     * @param rsql rsql filter for {@link Target}
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET)
+    void updateTargetGroupsWithRsql(@NotEmpty String group, @NotNull String rsql);
+
+    /**
+     * Updates the groups of targets which are in the provided list of controllerIds.
+     *
+     * @param group target group parameter
+     * @param controllerIds list of targets
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET)
+    void updateTargetsWithGroup(String group, @NotEmpty List<String> controllerIds);
+
+    /**
      * updates the {@link Target}.
      *
      * @param update to be updated

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetCreate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetCreate.java
@@ -74,6 +74,12 @@ public interface TargetCreate {
     TargetCreate status(@NotNull TargetUpdateStatus status);
 
     /**
+     * @param group for setting the group of the target
+     * @return updated builder instance
+     */
+    TargetCreate targetGroup(String group);
+
+    /**
      * @return peek on current state of {@link Target} in the builder
      */
     Target build();

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetUpdate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/TargetUpdate.java
@@ -70,4 +70,11 @@ public interface TargetUpdate {
      * @return updated builder instance
      */
     TargetUpdate requestAttributes(Boolean requestAttributes);
+
+    /**
+     *
+     * @param group for {@link Target#getTargetGroup()}
+     * @return updated builder instance
+     */
+    TargetUpdate targetGroup(String group);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Target.java
@@ -124,4 +124,10 @@ public interface Target extends NamedEntity {
      *         {@link #getControllerAttributes()}.
      */
     boolean isRequestControllerAttributes();
+
+    /**
+     *
+     * @return the group of the target
+     */
+    String getTargetGroup();
 }

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractTargetUpdateCreate.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractTargetUpdateCreate.java
@@ -34,6 +34,7 @@ public class AbstractTargetUpdateCreate<T> extends AbstractNamedEntityBuilder<T>
     protected TargetUpdateStatus status;
     protected Boolean requestAttributes;
     protected Long targetTypeId;
+    protected String targetGroup;
 
     protected AbstractTargetUpdateCreate(final String controllerId) {
         this.controllerId = AbstractBaseEntityBuilder.strip(controllerId);
@@ -83,6 +84,11 @@ public class AbstractTargetUpdateCreate<T> extends AbstractNamedEntityBuilder<T>
         return (T) this;
     }
 
+    public T targetGroup(final String targetGroup) {
+        this.targetGroup = targetGroup;
+        return (T) this;
+    }
+
     public String getControllerId() {
         return controllerId;
     }
@@ -106,5 +112,7 @@ public class AbstractTargetUpdateCreate<T> extends AbstractNamedEntityBuilder<T>
     public Long getTargetTypeId() {
         return targetTypeId;
     }
+
+    public Optional<String> getTargetGroup() { return Optional.ofNullable(targetGroup); }
 
 }

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/H2/V1_12_33__add_group_to_target__H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/H2/V1_12_33__add_group_to_target__H2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_target ADD COLUMN target_group VARCHAR(256);
+CREATE INDEX sp_idx_target_group_01 ON sp_target (tenant, target_group);

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/MYSQL/V1_12_33__add_group_to_target__MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/MYSQL/V1_12_33__add_group_to_target__MYSQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_target ADD COLUMN target_group VARCHAR(256);
+CREATE INDEX sp_idx_target_group_01 ON sp_target (tenant, target_group);

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/POSTGRESQL/V1_12_34__add_group_to_target__POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/POSTGRESQL/V1_12_34__add_group_to_target__POSTGRESQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_target ADD COLUMN target_group VARCHAR(256);
+CREATE INDEX sp_idx_target_group_01 ON sp_target (tenant, target_group);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaTargetCreate.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaTargetCreate.java
@@ -53,6 +53,7 @@ public class JpaTargetCreate extends AbstractTargetUpdateCreate<TargetCreate> im
         target.setAddress(address);
         target.setUpdateStatus(getStatus().orElse(TargetUpdateStatus.UNKNOWN));
         getLastTargetQuery().ifPresent(target::setLastTargetQuery);
+        target.setTargetGroup(getTargetGroup().orElse(null));
 
         return target;
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTarget.java
@@ -154,6 +154,11 @@ public class JpaTarget extends AbstractJpaNamedEntity implements Target, EventAw
     // set default request controller attributes to true, because we want to request them the first time
     private boolean requestControllerAttributes = true;
 
+    @Setter
+    @Getter
+    @Column(name = "target_group")
+    private String targetGroup;
+
     // actually it is OneToOne - but lazy loading is not supported for OneToOne (at least for hibernate 6.6.2)
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "target", cascade = { CascadeType.ALL }, orphanRemoval = true)
     @PrimaryKeyJoinColumn

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/TargetRepository.java
@@ -10,6 +10,7 @@
 package org.eclipse.hawkbit.repository.jpa.repository;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.persistence.EntityManager;
@@ -96,4 +97,7 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget> {
     @Transactional
     @Query("DELETE FROM JpaTarget t WHERE t.tenant = :tenant")
     void deleteByTenant(@Param("tenant") String tenant);
+
+    @Query("SELECT DISTINCT t.targetGroup FROM JpaTarget t WHERE t.targetGroup IS NOT NULL")
+    List<String> findDistinctGroups();
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.ListJoin;
@@ -45,6 +46,7 @@ import org.eclipse.hawkbit.repository.model.Target;
 import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.TargetUpdateStatus;
+import org.eclipse.persistence.jpa.jpql.tools.spi.IQuery;
 import org.springframework.data.jpa.domain.Specification;
 
 /**
@@ -189,6 +191,20 @@ public final class TargetSpecifications {
             return cb.or(
                     cb.like(cb.lower(targetRoot.get(JpaTarget_.controllerId)), searchTextToLower),
                     cb.like(cb.lower(targetRoot.get(AbstractJpaNamedEntity_.name)), searchTextToLower));
+        };
+    }
+
+    public  static Specification<JpaTarget> eqTargetGroup(final String targetGroup) {
+        return (targetRoot, query, criteriaBuilder) -> {
+            final String groupTextToLower = targetGroup.toLowerCase();
+            return criteriaBuilder.equal(criteriaBuilder.lower(targetRoot.get(JpaTarget_.targetGroup)), groupTextToLower);
+        };
+    }
+
+    public static Specification<JpaTarget> likeTargetGroup(final String targetGroupSearch) {
+        return (targetRoot, query, criteriaBuilder) ->  {
+            final String searchTextToLower = targetGroupSearch.toLowerCase();
+            return criteriaBuilder.like(criteriaBuilder.lower(targetRoot.get(JpaTarget_.targetGroup)), searchTextToLower);
         };
     }
 

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/Constants.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/Constants.java
@@ -21,6 +21,7 @@ public interface Constants {
     String VERSION = "Version";
     String VENDOR = "Vendor";
     String TYPE = "Type";
+    String GROUP = "Group";
     String CREATED_BY = "Created by";
     String CREATED_AT = "Created at";
     String LAST_MODIFIED_BY = "Last modified by";

--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/TargetView.java
@@ -345,6 +345,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
         private final TextField lastModifiedAt = Utils.textField(Constants.LAST_MODIFIED_AT);
         private final TextField securityToken = Utils.textField(Constants.SECURITY_TOKEN);
         private final TextField lastPoll = Utils.textField(Constants.LAST_POLL);
+        private final TextField targetGroup = Utils.textField(Constants.GROUP);
         private final TextArea targetAttributes = new TextArea(Constants.ATTRIBUTES);
         private transient MgmtTarget target;
 
@@ -355,7 +356,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
                             description,
                             createdBy, createdAt,
                             lastModifiedBy, lastModifiedAt,
-                            securityToken, lastPoll, targetAttributes
+                            securityToken, lastPoll, targetAttributes, targetGroup
                     )
                     .forEach(field -> {
                         field.setReadOnly(true);
@@ -378,6 +379,7 @@ public class TargetView extends TableView<MgmtTarget, String> {
             lastModifiedBy.setValue(target.getLastModifiedBy());
             lastModifiedAt.setValue(new Date(target.getLastModifiedAt()).toString());
             securityToken.setValue(target.getSecurityToken());
+            targetGroup.setValue(target.getGroup() != null ? target.getGroup() : "");
 
             final MgmtPollStatus pollStatus = target.getPollStatus();
             lastPoll.setValue(pollStatus == null ? NOT_AVAILABLE_NULL : new Date(pollStatus.getLastRequestAt()).toString());


### PR DESCRIPTION
In order to be provide option to group devices in different groups introducing new field/attribute to the targets (sp_target / JpaTarget). Though at the moment the targets have target type and metadata / attributes which also allows for grouping, this has drawbacks:

-  target type is related with a concrete device discrimination based on things like hardware type. It is related to the distribution sets that could be installed. Groups will provide different way of separation
- to filter against metadata / attributes - joins of target table shall be made which does thins much more heavy.

Current PR introduces target_group field in JpaTarget where : 

1. The paths support hierarchy - e.g. x/y/z, and the search should provide all devices in sub groups
2. Proper indexing so the searches work fine
3. Group is part of sp_target - so the query is fast
4. Initial Simple UI support 

Search could be made with direct equals of provided group, but also with filter based group : 
If we have groups like x/y/z we are able to search for targets matching x/y/*.
