### PR TITLE
Remove 'typeName' from ds rsql filtering

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
@@ -31,7 +31,6 @@ public enum DistributionSetFields implements RsqlQueryField {
     COMPLETE("complete"),
     MODULE("modules", SoftwareModuleFields.ID.getJpaEntityFieldName(), SoftwareModuleFields.NAME.getJpaEntityFieldName()),
     TAG("tags", "name"),
-    TYPENAME("typeName"),
     METADATA("metadata"),
     VALID("valid");
 // @formatter:on

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
@@ -22,7 +22,7 @@ public enum DistributionSetFields implements RsqlQueryField {
 
 // @formatter:off
     ID("id"),
-    TYPE("type", "key"),
+    TYPE("type", "key", "name"),
     NAME("name"),
     DESCRIPTION("description"),
     CREATEDAT("createdAt"),

--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/repository/DistributionSetFields.java
@@ -20,7 +20,6 @@ import lombok.Getter;
 @Getter
 public enum DistributionSetFields implements RsqlQueryField {
 
-// @formatter:off
     ID("id"),
     TYPE("type", "key", "name"),
     NAME("name"),
@@ -33,7 +32,6 @@ public enum DistributionSetFields implements RsqlQueryField {
     TAG("tags", "name"),
     METADATA("metadata"),
     VALID("valid");
-// @formatter:on
 
     private final String jpaEntityFieldName;
     private final List<String> subEntityAttributes;


### PR DESCRIPTION
Introduced in [#2554](https://github.com/eclipse-hawkbit/hawkbit/pull/2554/)
Currently there is a type reference to a ds, so 'TypeName' should be removed and 'type.name' key should be used for rsql