### PR TITLE
Add Spotless for Code Formatting

### DIFF
--- a/.github/workflows/reusable_workflow_verify.yaml
+++ b/.github/workflows/reusable_workflow_verify.yaml
@@ -61,5 +61,12 @@ jobs:
       - name: Check file license headers
         run: mvn license:check -PcheckLicense --batch-mode
 
+      - name: Check code style
+        run:  |
+          # compare style to target branch
+          git remote add target ${{ github.event.pull_request.base.repo.clone_url }}
+          git fetch target
+          mvn spotless:check -DratchetFrom=${{ github.event.pull_request.base.sha }}
+
       - name: Run tests & javadoc
         run: mvn clean verify javadoc:javadoc -DdetectOfflineLinks=false -PgenerateTestReport ${{ inputs.maven_properties }} --batch-mode

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,25 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <!--
+                https://github.com/diffplug/spotless/tree/main/plugin-maven#-spotless-keep-your-code-spotless-with-maven
+
+                Usage:
+                mvn spotless:apply
+                mvn spotless:check
+                -->
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <configuration>
+                    <ratchetFrom>origin/master</ratchetFrom>
+                    <java>
+                        <eclipse>
+                            <file>${maven.multiModuleProjectDirectory}/eclipse_codeformatter.xml</file>
+                        </eclipse>
+                    </java>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <!-- Dash tool integration - END -->
 
         <skipPublishing>false</skipPublishing>
+        <ratchetFrom>origin/master</ratchetFrom>
     </properties>
 
     <developers>
@@ -379,7 +380,7 @@
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <configuration>
-                    <ratchetFrom>origin/master</ratchetFrom>
+                    <ratchetFrom>${ratchetFrom}</ratchetFrom>
                     <java>
                         <eclipse>
                             <file>${maven.multiModuleProjectDirectory}/eclipse_codeformatter.xml</file>


### PR DESCRIPTION
**Description**
This PR adds [Spotless](https://github.com/diffplug/spotless) to enforce consistent code style across the project.
Spotless can automatically check and format Java code.

**How to Use**
- Run `mvn spotless:apply` to format all files
- CI will fail if formatting violations exist

**Why**
- **Consistency**: Enforces uniform code style across contributors.
- **Automation**: Reduces manual formatting effort
- **Onboarding**: Lowers friction for new contributors.
- **Review Focus**: Lets PR reviews prioritize logic over style.
