### PR TITLE
simple-ui: fix NPE on filters

### DIFF
--- a/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/util/Filter.java
+++ b/hawkbit-simple-ui/src/main/java/org/eclipse/hawkbit/ui/simple/view/util/Filter.java
@@ -116,13 +116,14 @@ public class Filter extends Div {
         final Map<Object, Object> normalized = new HashMap<>(keyToValues)
                 .entrySet()
                 .stream()
-                .map(e -> {
+                .filter(e -> {
                     if (e.getValue() instanceof Optional<?> opt) {
-                        e.setValue(opt.orElse(null));
+                        return opt.isPresent();
+                    } else {
+                        return e.getValue() != null;
                     }
-                    return e;
                 })
-                .filter(e -> !ObjectUtils.isEmpty(e))
+                .filter(e -> !(e.getValue() instanceof Collection<?> coll && coll.isEmpty()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (normalized.isEmpty()) {
             return null;


### PR DESCRIPTION
Since commit d2b8e740565796704a7bbb1634b09c5b18fdeadf an NPE was introduced on the filters. If no filter is provided, the views other than targets raise NPE.

I reverted the changes on the impacted lines to a proper Optional check. 

If any of you understands the change and why relying on null here, I'll be glad to update the code to match the desired new behavior.