### PR TITLE
Fix test assertions that depend on undefined row ordering

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/AutoAssignTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/AutoAssignTest.java
@@ -76,6 +76,6 @@ class AutoAssignTest extends AbstractAccessControllerManagementTest {
                 .as("Only updatable targets should be part of the rollout")
                 // all targets are distribution set type 2 compatible, but since user has UPDATE_TARGET only for targets of type 2
                 // only target2 and target3 shall be assigned
-                .containsExactly(target2Type2.getId(), target3Type2.getId());
+                .containsExactlyInAnyOrder(target2Type2.getId(), target3Type2.getId());
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ControllerManagementTest.java
@@ -1439,10 +1439,9 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
                 root.get(JpaAction_.externalRef).in(allExternalRef),
                 cb.equal(root.get(JpaAction_.active), true)
         )).stream().map(Action.class::cast).toList();
-        assertThat(foundAction).isNotNull();
-        for (int i = 0; i < numberOfActions; i++) {
-            assertThat(foundAction.get(i).getId()).isEqualTo(allActionId.get(i));
-        }
+        assertThat(foundAction).isNotNull().hasSize(numberOfActions);
+        assertThat(foundAction).extracting(Action::getId)
+                .containsExactlyInAnyOrderElementsOf(allActionId);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetFilterQueryManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetFilterQueryManagementTest.java
@@ -520,7 +520,7 @@ class TargetFilterQueryManagementTest extends AbstractRepositoryManagementTest<T
 
     private void verifyExpectedFilterQueriesInList(final Slice<TargetFilterQuery> tfqList,
             final TargetFilterQuery... expectedFilterQueries) {
-        assertThat(tfqList.map(TargetFilterQuery::getId)).containsExactly(
+        assertThat(tfqList.map(TargetFilterQuery::getId)).containsExactlyInAnyOrder(
                 Arrays.stream(expectedFilterQueries).map(TargetFilterQuery::getId).toArray(Long[]::new));
     }
 
@@ -536,7 +536,7 @@ class TargetFilterQueryManagementTest extends AbstractRepositoryManagementTest<T
             final TargetFilterQuery... expectedFilterQueries) {
         assertThat(expectedFilterQueries).as("Target filter query count").hasSize((int) tfqList.getTotalElements());
 
-        assertThat(tfqList.map(TargetFilterQuery::getId)).containsExactly(
+        assertThat(tfqList.map(TargetFilterQuery::getId)).containsExactlyInAnyOrder(
                 Arrays.stream(expectedFilterQueries).map(TargetFilterQuery::getId).toArray(Long[]::new));
     }
 


### PR DESCRIPTION
## Summary

Several integration tests use order-sensitive assertions (`containsExactly`, index-based access) on query results from queries with no `ORDER BY` clause. SQL does not guarantee row ordering without explicit `ORDER BY`, and this causes deterministic test failures on databases that don't return rows in insertion order (e.g. YugabyteDB, CockroachDB, or any distributed PostgreSQL-compatible DB).

The tests verify set membership (correct targets assigned, correct actions stored), not ordering. Changed to order-independent assertions:

- **AutoAssignTest** (3 tests): `containsExactly` → `containsExactlyInAnyOrder` on `findByAssignedDistributionSet()` results
- **ControllerManagementTest.updatedExternalRefOnActionIsReallyUpdated**: index-based loop → `containsExactlyInAnyOrderElementsOf`
- **TargetFilterQueryManagementTest**: `containsExactly` → `containsExactlyInAnyOrder` in `verifyExpectedFilterQueriesInList` helpers

## Test plan

- [x] Verified passing on H2 (default)
- [x] Verified passing on YugabyteDB (PostgreSQL 15.12-YB-2025.2.2.2-b0)
- [ ] Verify passing on PostgreSQL
- [ ] Verify passing on MySQL