### PR TITLE
Fix LIKE on non-String fields failing on PostgreSQL

### DIFF
--- a/hawkbit-ql-jpa/src/main/java/org/eclipse/hawkbit/ql/jpa/SpecificationBuilder.java
+++ b/hawkbit-ql-jpa/src/main/java/org/eclipse/hawkbit/ql/jpa/SpecificationBuilder.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.persistence.PersistenceException;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
@@ -373,41 +372,29 @@ public class SpecificationBuilder<T> {
             }
         }
 
-        @SuppressWarnings("java:S1872") // java:S1872 - sometimes class could be unavailable at runtime
         private Predicate like(final Path<String> fieldPath, final String sqlValue) {
-            try {
-                if (caseWise(fieldPath)) {
-                    return cb.like(cb.upper(fieldPath), sqlValue.toUpperCase(), ESCAPE_CHAR);
-                } else {
-                    return cb.like(fieldPath, sqlValue, ESCAPE_CHAR);
-                }
-            } catch (final PersistenceException e) {
-                if ("%".equals(sqlValue) && fieldPath.getJavaType() != String.class &&
-                        "org.hibernate.type.descriptor.java.CoercionException".equals(e.getClass().getName())) {
-                    // hibernate throws an exception if we try to do == on non-string field with wildcard only
-                    return fieldPath.isNotNull();
-                } else {
-                    throw e;
-                }
+            // LIKE on non-String fields (e.g. bigint) with wildcard-only value is equivalent to IS NOT NULL.
+            // Must be checked before building the SQL predicate because some databases (PostgreSQL, YugabyteDB)
+            // reject LIKE on non-text columns at the SQL level, before any JPA-provider-level validation.
+            if ("%".equals(sqlValue) && fieldPath.getJavaType() != String.class) {
+                return fieldPath.isNotNull();
+            }
+            if (caseWise(fieldPath)) {
+                return cb.like(cb.upper(fieldPath), sqlValue.toUpperCase(), ESCAPE_CHAR);
+            } else {
+                return cb.like(fieldPath, sqlValue, ESCAPE_CHAR);
             }
         }
 
-        @SuppressWarnings("java:S1872") // java:S1872 - sometimes class could be unavailable at runtime
         private Predicate notLike(final Path<String> fieldPath, final String sqlValue) {
-            try {
-                if (caseWise(fieldPath)) {
-                    return cb.notLike(cb.upper(fieldPath), sqlValue.toUpperCase(), ESCAPE_CHAR);
-                } else {
-                    return cb.notLike(fieldPath, sqlValue, ESCAPE_CHAR);
-                }
-            } catch (final PersistenceException e) {
-                if ("%".equals(sqlValue) && fieldPath.getJavaType() != String.class &&
-                        "org.hibernate.type.descriptor.java.CoercionException".equals(e.getClass().getName())) {
-                    // hibernate throws an exception if we try to do == on non-string field with wildcard only
-                    return fieldPath.isNull();
-                } else {
-                    throw e;
-                }
+            // NOT LIKE on non-String fields with wildcard-only value is equivalent to IS NULL.
+            if ("%".equals(sqlValue) && fieldPath.getJavaType() != String.class) {
+                return fieldPath.isNull();
+            }
+            if (caseWise(fieldPath)) {
+                return cb.notLike(cb.upper(fieldPath), sqlValue.toUpperCase(), ESCAPE_CHAR);
+            } else {
+                return cb.notLike(fieldPath, sqlValue, ESCAPE_CHAR);
             }
         }
 


### PR DESCRIPTION
## Summary

The `like()` and `notLike()` methods in `SpecificationBuilder` handle RSQL wildcard queries like `id==*` by translating them to SQL `LIKE '%'`. When applied to non-String columns (e.g. `bigint`), this fails on PostgreSQL and compatible databases with:

```
ERROR: operator does not exist: bigint ~~ text
```

The existing code had a fallback that caught Hibernate's `CoercionException` to convert this to `IS NOT NULL`, but:
1. The project uses **EclipseLink**, not Hibernate — so the exception was never thrown
2. EclipseLink sends the invalid SQL directly to the database, which rejects it
3. This means the test `DeploymentManagementTest.verifyActionVisibility` has **never passed on PostgreSQL** — only on H2

The fix moves the non-String field check **before** building the SQL predicate, making it both database-agnostic and JPA-provider-agnostic. The semantic equivalence is preserved: `LIKE '%'` on a non-null column matches all rows, same as `IS NOT NULL`.

## Changes

- `SpecificationBuilder.like()`: early return `isNotNull()` when `sqlValue` is `%` and field is non-String
- `SpecificationBuilder.notLike()`: early return `isNull()` for the same case
- Removed the now-unnecessary try/catch and unused `PersistenceException` import

## Test plan

- [x] `DeploymentManagementTest.verifyActionVisibility` passes on H2 (default)
- [x] `DeploymentManagementTest.verifyActionVisibility` passes on PostgreSQL 15
- [x] `DeploymentManagementTest.verifyActionVisibility` passes on YugabyteDB (PostgreSQL 15.12-YB-2025.2.2.2-b0)