### PR TITLE
Add @OrderBy to JpaRollout.rolloutGroups to fix rollout on PostgreSQL

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
@@ -28,6 +28,7 @@ import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedEntityGraphs;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.Max;
@@ -64,6 +65,7 @@ import org.eclipse.hawkbit.repository.model.TotalTargetCountStatus;
 public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, EventAwareEntity {
 
     @OneToMany(targetEntity = JpaRolloutGroup.class, fetch = FetchType.LAZY, cascade = { CascadeType.REMOVE }, mappedBy = "rollout")
+    @OrderBy("id ASC")
     private List<JpaRolloutGroup> rolloutGroups = new ArrayList<>();
 
     @Setter


### PR DESCRIPTION
## Summary

The `rolloutGroups` `@OneToMany` collection in `JpaRollout` lacks an `@OrderBy` annotation, leaving iteration order undefined. Multiple code paths depend on this list being ordered by creation time (ascending ID):

- `JpaRolloutExecutor.fillDynamicRolloutGroupsWithTargets()` uses `.get(size()-1)` to find the latest dynamic group
- `JpaRolloutExecutor.handleRunningRollout()` uses `.get(size()-1)` to identify the last group
- `RolloutHelper.toPercentFromTheRest()` iterates groups in sequence to calculate target percentages (comment in code: *"assume that the groups are served orderly"*)
- `JpaRolloutManagement.resumeRollout()` takes the last element of a filtered list as the "last started group"

On H2 rows happen to be returned in insertion order, but **PostgreSQL** and compatible databases do not guarantee any ordering without explicit `ORDER BY`. This causes:
- Spurious dynamic group creation (expected 2 groups, got 3)
- Wrong action counts per group (expected 3 running, got 5-7)
- Group status transitions stuck in SCHEDULED instead of RUNNING

## Changes

Added `@OrderBy("id ASC")` to `JpaRollout.rolloutGroups`. This makes the JPA provider include `ORDER BY` when loading the collection, fulfilling the ordering assumption the code already relies on.

## Test plan

- [x] `RolloutManagementFlowTest` (10 tests) passes on H2 (default)
- [x] `RolloutManagementFlowTest` (10 tests) passes on PostgreSQL 15
- [x] `RolloutManagementFlowTest` (10 tests) passes on YugabyteDB (PostgreSQL 15.12-YB-2025.2.2.2-b0)