### PR TITLE
Fix swallow OptimisticLockingFailureException as GenericSpServerExcep…

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa-api/src/main/java/org/eclipse/hawkbit/repository/jpa/utils/ExceptionMapper.java
+++ b/hawkbit-repository/hawkbit-repository-jpa-api/src/main/java/org/eclipse/hawkbit/repository/jpa/utils/ExceptionMapper.java
@@ -44,7 +44,6 @@ public class ExceptionMapper {
 
     static {
         MAPPED_EXCEPTION_ORDER.add(DuplicateKeyException.class);
-        MAPPED_EXCEPTION_ORDER.add(OptimisticLockingFailureException.class);
         MAPPED_EXCEPTION_ORDER.add(AccessDeniedException.class);
 
         EXCEPTION_MAPPING.put(DuplicateKeyException.class.getName(), EntityAlreadyExistsException.class.getName());


### PR DESCRIPTION
…tion that prevents @Retryable(includes = ConcurrencyFailureException.class) to work as expected

Having entry 'OptimisticLockingFailureException' in 'MAPPED_EXCEPTION_ORDER' but not in 'EXCEPTION_MAPPING' (leftover) forces ExceptionMapper to map it to 'GenericSpServerException' which then breaks completely all the annotations for retry:
`@Retryable(includes = ConcurrencyFailureException.class,`

Removing it from 'MAPPED_EXCEPTION_ORDER' now just returns it as is -> 'ConcurrencyFailureException' that will be handled by the '@Retryable' annotations.