### PR TITLE
Fix RSQL filter in batch update query in assign target group

### DIFF
--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetGroupResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetGroupResourceTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtRestConstants;
 import org.eclipse.hawkbit.mgmt.rest.api.MgmtTargetGroupRestApi;
+import org.eclipse.hawkbit.repository.TargetTagManagement;
+import org.eclipse.hawkbit.repository.model.TargetTag;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -228,5 +230,31 @@ public class MgmtTargetGroupResourceTest extends AbstractManagementApiIntegratio
                 .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target1")))
                 .andExpect(jsonPath("content.[1].controllerId", Matchers.equalTo("target2")))
                 .andExpect(jsonPath("content.[2].controllerId", Matchers.equalTo("target3")));
+    }
+
+    @Test
+    void shouldAssignGroupToTargetsFilteredByTagNotEqual() throws Exception {
+        targetManagement.create(builder().controllerId("target1").build());
+        targetManagement.create(builder().controllerId("target2").build());
+        targetManagement.create(builder().controllerId("target3").build());
+
+        final TargetTag tag1 = targetTagManagement.create(TargetTagManagement.Create.builder().name("tag1").build());
+        final TargetTag tag2 = targetTagManagement.create(TargetTagManagement.Create.builder().name("tag2").build());
+
+        targetManagement.assignTag(List.of("target1"), tag1.getId());
+        targetManagement.assignTag(List.of("target2"), tag1.getId());
+        targetManagement.assignTag(List.of("target3"), tag2.getId());
+
+        mvc.perform(put(MgmtTargetGroupRestApi.TARGETGROUPS_V1 + "/FilteredGroup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("q", "tag!=tag1"))
+                .andExpect(status().isNoContent());
+
+        mvc.perform(get(MgmtTargetGroupRestApi.TARGETGROUPS_V1 + "/FilteredGroup/assigned")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_SORTING, "ID:ASC")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("content", Matchers.hasSize(1)))
+                .andExpect(jsonPath("content.[0].controllerId", Matchers.equalTo("target3")));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
@@ -339,15 +339,21 @@ public class JpaTargetManagement
         final Root<JpaTarget> updateRoot = criteriaUpdateQuery.getRoot();
         criteriaUpdateQuery.set("group", group);
 
-        // Use a subquery to find matching IDs — avoids JOINs directly in UPDATE context
-        // which EclipseLink's UpdateAllQuery doesn't handle properly for anti-joins
-        final jakarta.persistence.criteria.Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
-        final Root<JpaTarget> subRoot = subquery.from(JpaTarget.class);
-        subquery.select(subRoot.get("id"));
-        final Predicate subPredicate = rsqlSpecification.toPredicate(subRoot, cb.createQuery(JpaTarget.class), cb);
-        subquery.where(subPredicate);
+        if (isEclipseLink()) {
+            // EclipseLink: use subquery approach — applying predicate directly to the UPDATE root
+            // fails for NOT EXISTS due to UpdateAllQuery's @Id resolution bug
+            final jakarta.persistence.criteria.Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
+            final Root<JpaTarget> subRoot = subquery.from(JpaTarget.class);
+            subquery.select(subRoot.get("id"));
+            subquery.where(rsqlSpecification.toPredicate(subRoot, cb.createQuery(JpaTarget.class), cb));
+            criteriaUpdateQuery.where(updateRoot.get("id").in(subquery));
+        } else {
+            // Hibernate: apply predicate directly to the UPDATE root — Hibernate handles
+            // NOT EXISTS subqueries correctly in CriteriaUpdate context
+            final Predicate predicate = rsqlSpecification.toPredicate(updateRoot, cb.createQuery(JpaTarget.class), cb);
+            criteriaUpdateQuery.where(predicate);
+        }
 
-        criteriaUpdateQuery.where(updateRoot.get("id").in(subquery));
         entityManager.createQuery(criteriaUpdateQuery).executeUpdate();
     }
 
@@ -439,6 +445,10 @@ public class JpaTargetManagement
         }
 
         jpaRepository.save(target);
+    }
+
+    private boolean isEclipseLink() {
+        return entityManager.getDelegate().getClass().getName().startsWith("org.eclipse.persistence");
     }
 
     private Map<String, String> getMap(final String controllerId, final MapAttribute<JpaTarget, String, String> mapAttribute) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
@@ -40,9 +40,11 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.TargetManagement;
 import org.eclipse.hawkbit.repository.exception.EntityAlreadyExistsException;
 import org.eclipse.hawkbit.repository.exception.EntityNotFoundException;
+import org.eclipse.hawkbit.repository.jpa.Jpa;
 import org.eclipse.hawkbit.repository.jpa.JpaManagementHelper;
 import org.eclipse.hawkbit.repository.jpa.acm.AccessController;
 import org.eclipse.hawkbit.repository.jpa.configuration.Constants;
+import org.eclipse.hawkbit.repository.jpa.model.AbstractJpaBaseEntity_;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetTag;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetType;
@@ -340,14 +342,14 @@ public class JpaTargetManagement
         final Root<JpaTarget> updateRoot = criteriaUpdateQuery.getRoot();
         criteriaUpdateQuery.set("group", group);
 
-        if (isEclipseLink()) {
+        if (Jpa.JPA_VENDOR == Jpa.JpaVendor.ECLIPSELINK) {
             // EclipseLink: use subquery approach — applying predicate directly to the UPDATE root
             // fails for NOT EXISTS due to UpdateAllQuery's @Id resolution bug
             final Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
             final Root<JpaTarget> subRoot = subquery.from(JpaTarget.class);
-            subquery.select(subRoot.get("id"));
+            subquery.select(subRoot.get(AbstractJpaBaseEntity_.ID));
             subquery.where(rsqlSpecification.toPredicate(subRoot, cb.createQuery(JpaTarget.class), cb));
-            criteriaUpdateQuery.where(updateRoot.get("id").in(subquery));
+            criteriaUpdateQuery.where(updateRoot.get(AbstractJpaBaseEntity_.ID).in(subquery));
         } else {
             // Hibernate: apply predicate directly to the UPDATE root — Hibernate handles
             // NOT EXISTS subqueries correctly in CriteriaUpdate context
@@ -446,10 +448,6 @@ public class JpaTargetManagement
         }
 
         jpaRepository.save(target);
-    }
-
-    private boolean isEclipseLink() {
-        return entityManager.getDelegate().getClass().getName().startsWith("org.eclipse.persistence");
     }
 
     private Map<String, String> getMap(final String controllerId, final MapAttribute<JpaTarget, String, String> mapAttribute) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
@@ -31,6 +31,7 @@ import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.MapJoin;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.validation.constraints.NotEmpty;
 
@@ -342,7 +343,7 @@ public class JpaTargetManagement
         if (isEclipseLink()) {
             // EclipseLink: use subquery approach — applying predicate directly to the UPDATE root
             // fails for NOT EXISTS due to UpdateAllQuery's @Id resolution bug
-            final jakarta.persistence.criteria.Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
+            final Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
             final Root<JpaTarget> subRoot = subquery.from(JpaTarget.class);
             subquery.select(subRoot.get("id"));
             subquery.where(rsqlSpecification.toPredicate(subRoot, cb.createQuery(JpaTarget.class), cb));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
@@ -345,6 +345,7 @@ public class JpaTargetManagement
         if (Jpa.JPA_VENDOR == Jpa.JpaVendor.ECLIPSELINK) {
             // EclipseLink: use subquery approach — applying predicate directly to the UPDATE root
             // fails for NOT EXISTS due to UpdateAllQuery's @Id resolution bug
+            // BUG Reported: https://github.com/eclipse-ee4j/eclipselink/issues/2757
             final Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
             final Root<JpaTarget> subRoot = subquery.from(JpaTarget.class);
             subquery.select(subRoot.get(AbstractJpaBaseEntity_.ID));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetManagement.java
@@ -336,12 +336,18 @@ public class JpaTargetManagement
 
         final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         final CriteriaUpdate<JpaTarget> criteriaUpdateQuery = cb.createCriteriaUpdate(JpaTarget.class);
-        final Root<JpaTarget> root = criteriaUpdateQuery.getRoot();
+        final Root<JpaTarget> updateRoot = criteriaUpdateQuery.getRoot();
         criteriaUpdateQuery.set("group", group);
-        // get predicate from rsql specification using a dummy query in order to execute batch update
-        final Predicate predicate = rsqlSpecification.toPredicate(root, entityManager.getCriteriaBuilder().createQuery(JpaTarget.class), cb);
-        criteriaUpdateQuery.where(predicate);
 
+        // Use a subquery to find matching IDs — avoids JOINs directly in UPDATE context
+        // which EclipseLink's UpdateAllQuery doesn't handle properly for anti-joins
+        final jakarta.persistence.criteria.Subquery<Long> subquery = criteriaUpdateQuery.subquery(Long.class);
+        final Root<JpaTarget> subRoot = subquery.from(JpaTarget.class);
+        subquery.select(subRoot.get("id"));
+        final Predicate subPredicate = rsqlSpecification.toPredicate(subRoot, cb.createQuery(JpaTarget.class), cb);
+        subquery.where(subPredicate);
+
+        criteriaUpdateQuery.where(updateRoot.get("id").in(subquery));
         entityManager.createQuery(criteriaUpdateQuery).executeUpdate();
     }
 


### PR DESCRIPTION
Refactor assignTargetGroupWithRsql to use a subquery-based approach 
`(WHERE id IN (SELECT id FROM ... WHERE <rsql_predicate>))` 
instead of applying the RSQL predicate directly to the CriteriaUpdate root.

The NOT EXISTS subquery generated by SpecificationBuilder.notEqualInLike for negated set attribute filters (tag!=, tag=out=) requires JOINs that do not work correctly when attached to an UPDATE root in EclipseLink's UpdateAllQuery. By wrapping the RSQL spec in a SELECT subquery, all JOINs and correlated subqueries execute in a proper SELECT context

Add integration test verifying tag!=<value> filter works correctly
when assigning target groups via RSQL.

Old approach generated the following query : 
```
UPDATE sp_target t
SET t.group_ = 'FilteredGroup'
WHERE NOT EXISTS (
    SELECT t2 FROM sp_target t2
    LEFT JOIN sp_target_tags tt ON t2.id = tt.target_id
    LEFT JOIN sp_tag tag ON tt.tag_id = tag.id
    WHERE t2.id = t.id AND tag.name = 'tag1'
)
```
Which fails in EclipseLink — t.id correlation in the subquery references the UPDATE root, which EclipseLink's UpdateAllQuery can't resolve properly for inherited @Id fields.

New Approach : 
```
UPDATE sp_target t
SET t.group_ = 'FilteredGroup'
WHERE t.id IN (
    SELECT t1.id FROM sp_target t1
    WHERE NOT EXISTS (
        SELECT t2 FROM sp_target t2
        LEFT JOIN sp_target_tags tt ON t2.id = tt.target_id
        LEFT JOIN sp_tag tag ON tt.tag_id = tag.id
        WHERE t2.id = t1.id AND tag.name = 'tag1'
    )
)
```

Also this approach did not work for hibernate, so when using hibernate the old approach is applied.
Meaniong : EclipseLink takes the subquery path (WHERE id IN (SELECT ...))to avoid UpdateAllQuery's @Id resolution bug.
While Hibernate takes the direct predicate path for optimal single-statement execution.