### PR TITLE
Fix Error/Success Conditions not evaluated case. Fix 'Cancel' final s…

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/ActionRepository.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.hawkbit.repository.jpa.repository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -178,18 +177,6 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction> {
      * @return the count of actions referring to a rollout, rollout group and are in a given status
      */
     Long countByRolloutIdAndRolloutGroupIdAndStatus(Long rolloutId, Long rolloutGroupId, Action.Status status);
-
-    /**
-     * Counts all actions referring to a given rollout, rollout group and one of the given statuses.
-     * <p/>
-     * No access control applied
-     *
-     * @param rolloutId the ID of rollout the actions belong to
-     * @param rolloutGroupId the ID rollout group the actions belong to
-     * @param statuses the statuses to match
-     * @return the count of actions referring to a rollout, rollout group and are in any of the given statuses
-     */
-    Long countByRolloutIdAndRolloutGroupIdAndStatusIn(Long rolloutId, Long rolloutGroupId, Collection<Action.Status> statuses);
 
     /**
      * Counts all actions referring to a given rollout and status.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/ActionRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/ActionRepository.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.hawkbit.repository.jpa.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -177,6 +178,18 @@ public interface ActionRepository extends BaseEntityRepository<JpaAction> {
      * @return the count of actions referring to a rollout, rollout group and are in a given status
      */
     Long countByRolloutIdAndRolloutGroupIdAndStatus(Long rolloutId, Long rolloutGroupId, Action.Status status);
+
+    /**
+     * Counts all actions referring to a given rollout, rollout group and one of the given statuses.
+     * <p/>
+     * No access control applied
+     *
+     * @param rolloutId the ID of rollout the actions belong to
+     * @param rolloutGroupId the ID rollout group the actions belong to
+     * @param statuses the statuses to match
+     * @return the count of actions referring to a rollout, rollout group and are in any of the given statuses
+     */
+    Long countByRolloutIdAndRolloutGroupIdAndStatusIn(Long rolloutId, Long rolloutGroupId, Collection<Action.Status> statuses);
 
     /**
      * Counts all actions referring to a given rollout and status.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorCondition.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorCondition.java
@@ -9,18 +9,20 @@
  */
 package org.eclipse.hawkbit.repository.jpa.rollout.condition;
 
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.hawkbit.repository.jpa.repository.ActionRepository;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 
-/**
- * Evaluates if the {@link RolloutGroup#getErrorConditionExp()} is reached.
- */
 @Slf4j
 public class ThresholdRolloutGroupErrorCondition
         implements RolloutGroupConditionEvaluator<RolloutGroup.RolloutGroupErrorCondition> {
+
+    // Both ERROR and CANCELED are terminal failure statuses: the DS was not installed.
+    private static final List<Action.Status> ERROR_STATUSES = List.of(Action.Status.ERROR, Action.Status.CANCELED);
 
     private final ActionRepository actionRepository;
 
@@ -36,8 +38,8 @@ public class ThresholdRolloutGroupErrorCondition
     @Override
     public boolean eval(final Rollout rollout, final RolloutGroup rolloutGroup, final String expression) {
         final long totalGroup = rolloutGroup.getTotalTargets();
-        final Long error = actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(rollout.getId(),
-                rolloutGroup.getId(), Action.Status.ERROR);
+        final long error = actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(rollout.getId(),
+                rolloutGroup.getId(), ERROR_STATUSES);
         try {
             final int threshold = Integer.parseInt(expression);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorCondition.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorCondition.java
@@ -9,8 +9,6 @@
  */
 package org.eclipse.hawkbit.repository.jpa.rollout.condition;
 
-import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.hawkbit.repository.jpa.repository.ActionRepository;
 import org.eclipse.hawkbit.repository.model.Action;
@@ -20,9 +18,6 @@ import org.eclipse.hawkbit.repository.model.RolloutGroup;
 @Slf4j
 public class ThresholdRolloutGroupErrorCondition
         implements RolloutGroupConditionEvaluator<RolloutGroup.RolloutGroupErrorCondition> {
-
-    // Both ERROR and CANCELED are terminal failure statuses: the DS was not installed.
-    private static final List<Action.Status> ERROR_STATUSES = List.of(Action.Status.ERROR, Action.Status.CANCELED);
 
     private final ActionRepository actionRepository;
 
@@ -38,8 +33,8 @@ public class ThresholdRolloutGroupErrorCondition
     @Override
     public boolean eval(final Rollout rollout, final RolloutGroup rolloutGroup, final String expression) {
         final long totalGroup = rolloutGroup.getTotalTargets();
-        final long error = actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(rollout.getId(),
-                rolloutGroup.getId(), ERROR_STATUSES);
+        final Long error = actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(rollout.getId(),
+                rolloutGroup.getId(), Action.Status.ERROR);
         try {
             final int threshold = Integer.parseInt(expression);
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaRolloutExecutor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaRolloutExecutor.java
@@ -449,7 +449,7 @@ public class JpaRolloutExecutor implements RolloutExecutor {
                 // 'success' is either group completed or success condition reached - execute 'success' Action
                 boolean groupCompleted = !(rolloutGroup == lastGroup && rolloutGroup.isDynamic()) && isRolloutGroupComplete(rollout, rolloutGroup);
                 checkSuccessCondition(rollout, rolloutGroup, evalProxy, rolloutGroup.getSuccessCondition(), groupCompleted);
-                if (groupCompleted) {// if
+                if (groupCompleted) {
                     rolloutGroup.setStatus(RolloutGroupStatus.FINISHED);
                     rolloutGroupRepository.save(rolloutGroup);
                 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaRolloutExecutor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaRolloutExecutor.java
@@ -447,7 +447,7 @@ public class JpaRolloutExecutor implements RolloutExecutor {
                 callErrorAction(rollout, rolloutGroup);
             } else {// not in error so check success condition and group completed
                 // 'success' is either group completed or success condition reached - execute 'success' Action
-                boolean groupCompleted = !(rolloutGroup == lastGroup && rolloutGroup.isDynamic()) && isRolloutGroupComplete(rollout, rolloutGroup);
+                final boolean groupCompleted = !(rolloutGroup == lastGroup && rolloutGroup.isDynamic()) && isRolloutGroupComplete(rollout, rolloutGroup);
                 checkSuccessCondition(rollout, rolloutGroup, evalProxy, rolloutGroup.getSuccessCondition(), groupCompleted);
                 if (groupCompleted) {
                     rolloutGroup.setStatus(RolloutGroupStatus.FINISHED);
@@ -509,11 +509,10 @@ public class JpaRolloutExecutor implements RolloutExecutor {
             final RolloutGroupSuccessCondition successCondition, final boolean groupCompleted) {
         log.trace("Checking finish condition {} on rolloutgroup {}", successCondition, rolloutGroup);
         try {
-            final boolean isSuccessEvaluation = evaluationManager
+            if (groupCompleted || evaluationManager
                     .getSuccessConditionEvaluator(successCondition)
-                    .eval(rollout, evalProxy, rolloutGroup.getSuccessConditionExp());
-            if (isSuccessEvaluation || groupCompleted) {
-                log.debug("Rollout group {} is finished, executing Success Action", rolloutGroup);
+                    .eval(rollout, evalProxy, rolloutGroup.getSuccessConditionExp())) {
+                log.debug("Rollout group {} fulfills SuccessCondition or is Finished, executing Success Action", rolloutGroup);
                 evaluationManager.getSuccessActionEvaluator(rolloutGroup.getSuccessAction()).exec(rollout, rolloutGroup);
             } else {
                 log.debug("Rollout group {} is still running", rolloutGroup);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaRolloutExecutor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaRolloutExecutor.java
@@ -445,10 +445,11 @@ public class JpaRolloutExecutor implements RolloutExecutor {
             if (isError) {
                 log.info("Rollout {} {} has error, calling error action", rollout.getName(), rollout.getId());
                 callErrorAction(rollout, rolloutGroup);
-            } else {
-                // not in error so check finished state, do we need to start the next group?
-                checkSuccessCondition(rollout, rolloutGroup, evalProxy, rolloutGroup.getSuccessCondition());
-                if (!(rolloutGroup == lastGroup && rolloutGroup.isDynamic()) && isRolloutGroupComplete(rollout, rolloutGroup)) {
+            } else {// not in error so check success condition and group completed
+                // 'success' is either group completed or success condition reached - execute 'success' Action
+                boolean groupCompleted = !(rolloutGroup == lastGroup && rolloutGroup.isDynamic()) && isRolloutGroupComplete(rollout, rolloutGroup);
+                checkSuccessCondition(rollout, rolloutGroup, evalProxy, rolloutGroup.getSuccessCondition(), groupCompleted);
+                if (groupCompleted) {// if
                     rolloutGroup.setStatus(RolloutGroupStatus.FINISHED);
                     rolloutGroupRepository.save(rolloutGroup);
                 }
@@ -466,11 +467,9 @@ public class JpaRolloutExecutor implements RolloutExecutor {
     }
 
     private long countTargetsFrom(final JpaRolloutGroup rolloutGroup) {
-        if (rolloutGroup.isDynamic()) {
-            return countByActionsInRolloutGroup(rolloutGroup.getId());
-        } else {
-            return rolloutGroupManagement.countTargetsOfRolloutsGroup(rolloutGroup.getId());
-        }
+        // Use action-based count for all groups: deleting an action removes the target from the count,
+        // keeping totalTargets consistent with the actual denominator used by condition evaluators.
+        return countByActionsInRolloutGroup(rolloutGroup.getId());
     }
 
     private void callErrorAction(final Rollout rollout, final RolloutGroup rolloutGroup) {
@@ -507,14 +506,14 @@ public class JpaRolloutExecutor implements RolloutExecutor {
     }
 
     private void checkSuccessCondition(final Rollout rollout, final RolloutGroup rolloutGroup, final RolloutGroup evalProxy,
-            final RolloutGroupSuccessCondition successCondition) {
+            final RolloutGroupSuccessCondition successCondition, final boolean groupCompleted) {
         log.trace("Checking finish condition {} on rolloutgroup {}", successCondition, rolloutGroup);
         try {
-            final boolean isFinished = evaluationManager
+            final boolean isSuccessEvaluation = evaluationManager
                     .getSuccessConditionEvaluator(successCondition)
                     .eval(rollout, evalProxy, rolloutGroup.getSuccessConditionExp());
-            if (isFinished) {
-                log.debug("Rollout group {} is finished, starting next group", rolloutGroup);
+            if (isSuccessEvaluation || groupCompleted) {
+                log.debug("Rollout group {} is finished, executing Success Action", rolloutGroup);
                 evaluationManager.getSuccessActionEvaluator(rolloutGroup.getSuccessAction()).exec(rollout, rolloutGroup);
             } else {
                 log.debug("Rollout group {} is still running", rolloutGroup);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutGroupConditionTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutGroupConditionTest.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.repository.jpa.management;
+
+import static org.eclipse.hawkbit.repository.test.util.SecurityContextSwitch.callAs;
+import static org.eclipse.hawkbit.repository.test.util.SecurityContextSwitch.withUser;
+
+import java.util.List;
+
+import lombok.SneakyThrows;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
+import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
+import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Action.ActionStatusCreate;
+import org.eclipse.hawkbit.repository.model.DistributionSet;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "hawkbit.server.repository.dynamicRolloutsMinInvolvePeriodMS=-1" })
+class RolloutGroupConditionTest extends AbstractJpaIntegrationTest {
+
+    @BeforeEach
+    void reset() {
+        this.approvalStrategy.setApprovalNeeded(false);
+    }
+
+    @SneakyThrows
+    @Test
+    void canceledActionCountedAsError() {
+        final String targetPrefix = "bug3cancel";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("bug3cancelDs");
+        testdataFactory.createTargets(targetPrefix, 5);
+
+        final Rollout rollout = callAs(
+                withUser("bug3User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables("bug3cancelRollout", "bug3", 1,
+                        "controllerid==" + targetPrefix + "*", ds, "100", "10", null, null, false));
+
+        final RolloutGroup group = rolloutGroupManagement.findByRollout(
+                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+
+        rolloutManagement.start(rollout.getId());
+        rolloutHandler.handleAll();
+
+        final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
+
+        running.subList(0, 4).forEach(this::finishAction);
+        setCanceled(running.get(4));
+
+        rolloutHandler.handleAll();
+
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 1, 5);
+        assertGroup(group, false, RolloutGroupStatus.ERROR, 5);
+    }
+
+    @SneakyThrows
+    @Test
+    void groupCompleteWithSubthresholdErrorsFinishes() {
+        final String targetPrefix = "bug1complete";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("bug1completeDs");
+        testdataFactory.createTargets(targetPrefix, 5);
+
+        final Rollout rollout = callAs(
+                withUser("bug1User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables("bug1completeRollout", "bug1", 1,
+                        "controllerid==" + targetPrefix + "*", ds, "100", "50", null, null, false));
+
+        final RolloutGroup group = rolloutGroupManagement.findByRollout(
+                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+
+        rolloutManagement.start(rollout.getId());
+        rolloutHandler.handleAll();
+
+        final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
+
+        // 3 FINISHED (60%) + 2 ERROR (40%) — error below 50% threshold, no error action fires
+        running.subList(0, 3).forEach(this::finishAction);
+        running.subList(3, 5).forEach(this::reportError);
+
+        rolloutHandler.handleAll();
+
+        // group complete, error condition not breached → success action (NEXTGROUP) → FINISHED
+        assertGroup(group, false, RolloutGroupStatus.FINISHED, 5);
+        assertRollout(rollout, false, RolloutStatus.FINISHED, 1, 5);
+    }
+
+    @SneakyThrows
+    @Test
+    void deletedActionUpdatesCountDenominatorAndSuccessFires() {
+        final String targetPrefix = "bug2denom";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("bug2denomDs");
+        testdataFactory.createTargets(targetPrefix, 5);
+
+        final Rollout rollout = callAs(
+                withUser("bug2User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables("bug2denomRollout", "bug2", 1,
+                        "controllerid==" + targetPrefix + "*", ds, "100", "10", null, null, false));
+
+        final RolloutGroup group = rolloutGroupManagement.findByRollout(
+                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+
+        rolloutManagement.start(rollout.getId());
+        rolloutHandler.handleAll();
+
+        final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
+
+        // delete one action directly — simulates external action removal
+        actionRepository.deleteById(running.get(4).getId());
+        // finish the remaining 4
+        running.subList(0, 4).forEach(this::finishAction);
+
+        rolloutHandler.handleAll();
+
+        // totalTargets must be recalculated to 4; success=4/4=100% → FINISHED
+        assertGroup(group, false, RolloutGroupStatus.FINISHED, 4);
+        assertRollout(rollout, false, RolloutStatus.FINISHED, 1, 4);
+    }
+
+    @SneakyThrows
+    @Test
+    void deletedTargetUpdatesErrorThresholdDenominator() {
+        final String targetPrefix = "delTargetErr";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("delTargetErrDs");
+        testdataFactory.createTargets(targetPrefix, 5);
+
+        final Rollout rollout = callAs(
+                withUser("delTargetUser", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables("delTargetErrRollout", "delTarget", 1,
+                        "controllerid==" + targetPrefix + "*", ds, "100", "20", null, null, false));
+
+        final RolloutGroup group = rolloutGroupManagement.findByRollout(
+                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+
+        rolloutManagement.start(rollout.getId());
+        rolloutHandler.handleAll();
+
+        final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
+
+        // delete target at index 4 — cascades to action deletion, denominator drops from 5 to 4
+        targetManagement.delete(List.of(running.get(4).getTarget().getId()));
+        // finish 3, report error on 1 → error=1/4=25% > 20%
+        running.subList(0, 3).forEach(this::finishAction);
+        reportError(running.get(3));
+
+        rolloutHandler.handleAll();
+
+        // correct denominator=4: 1/4=25% > 20% → error fires → PAUSED
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 1, 4);
+        assertGroup(group, false, RolloutGroupStatus.ERROR, 4);
+    }
+
+    private void setCanceled(final JpaAction action) {
+        action.setStatus(Action.Status.CANCELED);
+        action.setActive(false);
+        actionRepository.save(action);
+    }
+
+    private void reportError(final Action action) {
+        controllerManagement.addUpdateActionStatus(
+                ActionStatusCreate.builder().actionId(action.getId()).status(Action.Status.ERROR).build());
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutGroupConditionTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutGroupConditionTest.java
@@ -41,14 +41,14 @@ class RolloutGroupConditionTest extends AbstractJpaIntegrationTest {
 
     @SneakyThrows
     @Test
-    void canceledActionCountedAsError() {
-        final String targetPrefix = "bug3cancel";
-        final DistributionSet ds = testdataFactory.createDistributionSetLocked("bug3cancelDs");
+    void canceledActionIgnoredGroupCompletionTriggersSuccessAction() {
+        final String targetPrefix = "cancelTarget";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("cancelTargetDs");
         testdataFactory.createTargets(targetPrefix, 5);
 
         final Rollout rollout = callAs(
-                withUser("bug3User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
-                () -> testdataFactory.createRolloutByVariables("bug3cancelRollout", "bug3", 1,
+                withUser("user", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables("cancelTargetRollout", "bug3", 1,
                         "controllerid==" + targetPrefix + "*", ds, "100", "10", null, null, false));
 
         final RolloutGroup group = rolloutGroupManagement.findByRollout(
@@ -64,8 +64,11 @@ class RolloutGroupConditionTest extends AbstractJpaIntegrationTest {
 
         rolloutHandler.handleAll();
 
-        assertRollout(rollout, false, RolloutStatus.PAUSED, 1, 5);
-        assertGroup(group, false, RolloutGroupStatus.ERROR, 5);
+        // CANCELED not counted as ERROR → error condition not triggered (0/5 = 0% < 10%)
+        // success condition not triggered (4/5 = 80% < 100%)
+        // group complete (CANCELED is terminal) → groupCompleted=true → Success Action (NEXTGROUP) fires
+        assertRollout(rollout, false, RolloutStatus.FINISHED, 1, 5);
+        assertGroup(group, false, RolloutGroupStatus.FINISHED, 5);
     }
 
     @SneakyThrows
@@ -162,6 +165,40 @@ class RolloutGroupConditionTest extends AbstractJpaIntegrationTest {
         // correct denominator=4: 1/4=25% > 20% → error fires → PAUSED
         assertRollout(rollout, false, RolloutStatus.PAUSED, 1, 4);
         assertGroup(group, false, RolloutGroupStatus.ERROR, 4);
+    }
+
+    @SneakyThrows
+    @Test
+    void successConditionMetBeforeGroupFinishedTriggersNextGroup() {
+        // 10 targets → 2 groups of 5. Success threshold 60%: fires when 3 of 5 finish, while 2 still running.
+        final String targetPrefix = "sc1";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("sc1Ds");
+        testdataFactory.createTargets(targetPrefix, 10);
+
+        final Rollout rollout = callAs(
+                withUser("sc1User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables("sc1Rollout", "sc1", 2,
+                        "controllerid==" + targetPrefix + "*", ds, "60", "90", null, null, false));
+
+        final List<RolloutGroup> groups = rolloutGroupManagement.findByRollout(
+                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent();
+
+        rolloutManagement.start(rollout.getId());
+        rolloutHandler.handleAll();
+
+        // only group 1 is RUNNING — 5 actions
+        final List<JpaAction> group1Actions = assertAndGetRunning(rollout, 5).getContent();
+
+        // finish 3 of 5 → 60% meets 60% success threshold; 2 still RUNNING in group 1
+        group1Actions.subList(0, 3).forEach(this::finishAction);
+
+        rolloutHandler.handleAll();
+
+        // success condition met (3/5 = 60%) before group 1 finishes → NEXTGROUP fires → group 2 starts
+        // group 1 stays RUNNING (2 actions still in progress, group not complete)
+        assertGroup(groups.get(0), false, RolloutGroupStatus.RUNNING, 5);
+        assertGroup(groups.get(1), false, RolloutGroupStatus.RUNNING, 5);
+        assertRollout(rollout, false, RolloutStatus.RUNNING, 2, 10);
     }
 
     private void setCanceled(final JpaAction action) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutGroupConditionTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutGroupConditionTest.java
@@ -25,12 +25,29 @@ import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
 import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupStatus;
+import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupSuccessAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.test.context.TestPropertySource;
 
+/**
+ * Integration tests for rollout group condition evaluation — group cascade behavior.
+ *
+ * Every test uses a 2-group rollout so both groups' final state is verified:
+ *   - group 1: the group under test
+ *   - group 2: verifies cascade (SCHEDULED = did not start, RUNNING = was triggered)
+ *
+ * Success-action tests use PAUSE: PauseRolloutGroupSuccessAction only fires when a
+ * scheduled child group exists, making success-action execution observable as
+ * RolloutStatus.PAUSED without advancing to group 2.
+ *
+ * Decision-log rules under test:
+ *   - Success Action fires on SuccessCondition OR GroupFINISHED
+ *   - CANCEL not mapped to Error (ignored in condition evaluation)
+ *   - Target's Action count used as Group Target count
+ */
 @TestPropertySource(properties = { "hawkbit.server.repository.dynamicRolloutsMinInvolvePeriodMS=-1" })
 class RolloutGroupConditionTest extends AbstractJpaIntegrationTest {
 
@@ -39,166 +56,154 @@ class RolloutGroupConditionTest extends AbstractJpaIntegrationTest {
         this.approvalStrategy.setApprovalNeeded(false);
     }
 
+    // -----------------------------------------------------------------------
+    // CANCELED ignored; group completion triggers success action
+    // -----------------------------------------------------------------------
+
     @SneakyThrows
     @Test
     void canceledActionIgnoredGroupCompletionTriggersSuccessAction() {
         final String targetPrefix = "cancelTarget";
         final DistributionSet ds = testdataFactory.createDistributionSetLocked("cancelTargetDs");
-        testdataFactory.createTargets(targetPrefix, 5);
+        testdataFactory.createTargets(targetPrefix, 10);
 
-        final Rollout rollout = callAs(
-                withUser("user", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
-                () -> testdataFactory.createRolloutByVariables("cancelTargetRollout", "bug3", 1,
-                        "controllerid==" + targetPrefix + "*", ds, "100", "10", null, null, false));
-
-        final RolloutGroup group = rolloutGroupManagement.findByRollout(
-                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+        final Rollout rollout = rolloutWith2Groups(
+                "cancelTargetRollout", targetPrefix, ds, "100", RolloutGroupSuccessAction.PAUSE, "10");
+        final List<RolloutGroup> groups = getGroups(rollout);
 
         rolloutManagement.start(rollout.getId());
         rolloutHandler.handleAll();
 
         final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
-
         running.subList(0, 4).forEach(this::finishAction);
         setCanceled(running.get(4));
 
         rolloutHandler.handleAll();
 
-        // CANCELED not counted as ERROR → error condition not triggered (0/5 = 0% < 10%)
-        // success condition not triggered (4/5 = 80% < 100%)
-        // group complete (CANCELED is terminal) → groupCompleted=true → Success Action (NEXTGROUP) fires
-        assertRollout(rollout, false, RolloutStatus.FINISHED, 1, 5);
-        assertGroup(group, false, RolloutGroupStatus.FINISHED, 5);
+        assertGroup(groups.get(0), false, RolloutGroupStatus.FINISHED, 5);
+        assertGroup(groups.get(1), false, RolloutGroupStatus.SCHEDULED, 5);
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 2, 10);
     }
 
     @SneakyThrows
     @Test
-    void groupCompleteWithSubthresholdErrorsFinishes() {
-        final String targetPrefix = "bug1complete";
-        final DistributionSet ds = testdataFactory.createDistributionSetLocked("bug1completeDs");
-        testdataFactory.createTargets(targetPrefix, 5);
+    void groupCompleteNeitherConditionFulfilledTriggersSuccessAction() {
+        final String targetPrefix = "subthreshold";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("subthresholdDs");
+        testdataFactory.createTargets(targetPrefix, 10);
 
-        final Rollout rollout = callAs(
-                withUser("bug1User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
-                () -> testdataFactory.createRolloutByVariables("bug1completeRollout", "bug1", 1,
-                        "controllerid==" + targetPrefix + "*", ds, "100", "50", null, null, false));
-
-        final RolloutGroup group = rolloutGroupManagement.findByRollout(
-                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+        final Rollout rollout = rolloutWith2Groups(
+                "subthreshRollout", targetPrefix, ds, "100", RolloutGroupSuccessAction.PAUSE, "50");
+        final List<RolloutGroup> groups = getGroups(rollout);
 
         rolloutManagement.start(rollout.getId());
         rolloutHandler.handleAll();
 
         final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
-
-        // 3 FINISHED (60%) + 2 ERROR (40%) — error below 50% threshold, no error action fires
+        // 3/5 SUCCESS, 2/5 ERRORS, neither condition fulfilled (S:100, E:50)
+        // but Group Finishes 5/5 -> execute SuccessAction#PAUSE
         running.subList(0, 3).forEach(this::finishAction);
         running.subList(3, 5).forEach(this::reportError);
 
         rolloutHandler.handleAll();
 
-        // group complete, error condition not breached → success action (NEXTGROUP) → FINISHED
-        assertGroup(group, false, RolloutGroupStatus.FINISHED, 5);
-        assertRollout(rollout, false, RolloutStatus.FINISHED, 1, 5);
+        assertGroup(groups.get(0), false, RolloutGroupStatus.FINISHED, 5);
+        assertGroup(groups.get(1), false, RolloutGroupStatus.SCHEDULED, 5);
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 2, 10);
     }
 
     @SneakyThrows
     @Test
-    void deletedActionUpdatesCountDenominatorAndSuccessFires() {
-        final String targetPrefix = "bug2denom";
-        final DistributionSet ds = testdataFactory.createDistributionSetLocked("bug2denomDs");
-        testdataFactory.createTargets(targetPrefix, 5);
+    void successConditionMetBeforeGroupFinishedTriggersSuccessAction() {
+        final String targetPrefix = "scBefore";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("scBeforeDs");
+        testdataFactory.createTargets(targetPrefix, 10);
 
-        final Rollout rollout = callAs(
-                withUser("bug2User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
-                () -> testdataFactory.createRolloutByVariables("bug2denomRollout", "bug2", 1,
-                        "controllerid==" + targetPrefix + "*", ds, "100", "10", null, null, false));
+        final Rollout rollout = rolloutWith2Groups(
+                "scBeforeRollout", targetPrefix, ds, "60", RolloutGroupSuccessAction.PAUSE, "90");
+        final List<RolloutGroup> groups = getGroups(rollout);
 
-        final RolloutGroup group = rolloutGroupManagement.findByRollout(
-                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+        rolloutManagement.start(rollout.getId());
+        rolloutHandler.handleAll();
+
+        final List<JpaAction> group1Actions = assertAndGetRunning(rollout, 5).getContent();
+        // 3/5 SUCCESS, 2/5 RUNNING -> fulfill 60% SuccessCondition => Trigger SuccessAction#PAUSE
+        group1Actions.subList(0, 3).forEach(this::finishAction);
+
+        rolloutHandler.handleAll();
+
+        assertGroup(groups.get(0), false, RolloutGroupStatus.RUNNING, 5);
+        assertGroup(groups.get(1), false, RolloutGroupStatus.SCHEDULED, 5);
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 2, 10);
+    }
+
+    @SneakyThrows
+    @Test
+    void deletedActionUpdatesGroupCountAndSuccessFires() {
+        final String targetPrefix = "denomSuccess";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("denomSuccessDs");
+        testdataFactory.createTargets(targetPrefix, 10);
+
+        final Rollout rollout = rolloutWith2Groups(
+                "denomSuccessRollout", targetPrefix, ds, "100", RolloutGroupSuccessAction.PAUSE, "10");
+        final List<RolloutGroup> groups = getGroups(rollout);
 
         rolloutManagement.start(rollout.getId());
         rolloutHandler.handleAll();
 
         final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
-
-        // delete one action directly — simulates external action removal
+        // 4/5 SUCCESS, 1 DELETE -> 4/4 SUCCESS fulfill SuccessCondition 100% => Trigger SuccessAction#PAUSE
         actionRepository.deleteById(running.get(4).getId());
-        // finish the remaining 4
         running.subList(0, 4).forEach(this::finishAction);
 
         rolloutHandler.handleAll();
 
-        // totalTargets must be recalculated to 4; success=4/4=100% → FINISHED
-        assertGroup(group, false, RolloutGroupStatus.FINISHED, 4);
-        assertRollout(rollout, false, RolloutStatus.FINISHED, 1, 4);
+        assertGroup(groups.get(0), false, RolloutGroupStatus.FINISHED, 4);
+        assertGroup(groups.get(1), false, RolloutGroupStatus.SCHEDULED, 5);
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 2, 9);
     }
 
     @SneakyThrows
     @Test
-    void deletedTargetUpdatesErrorThresholdDenominator() {
-        final String targetPrefix = "delTargetErr";
-        final DistributionSet ds = testdataFactory.createDistributionSetLocked("delTargetErrDs");
-        testdataFactory.createTargets(targetPrefix, 5);
+    void deletedActionUpdatesErrorDenominator() {
+        final String targetPrefix = "denomError";
+        final DistributionSet ds = testdataFactory.createDistributionSetLocked("denomErrorDs");
+        testdataFactory.createTargets(targetPrefix, 10);
 
-        final Rollout rollout = callAs(
-                withUser("delTargetUser", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
-                () -> testdataFactory.createRolloutByVariables("delTargetErrRollout", "delTarget", 1,
-                        "controllerid==" + targetPrefix + "*", ds, "100", "20", null, null, false));
-
-        final RolloutGroup group = rolloutGroupManagement.findByRollout(
-                rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent().get(0);
+        final Rollout rollout = rolloutWith2Groups(
+                "denomErrorRollout", targetPrefix, ds, "100", RolloutGroupSuccessAction.PAUSE, "23");
+        final List<RolloutGroup> groups = getGroups(rollout);
 
         rolloutManagement.start(rollout.getId());
         rolloutHandler.handleAll();
 
         final List<JpaAction> running = assertAndGetRunning(rollout, 5).getContent();
-
-        // delete target at index 4 — cascades to action deletion, denominator drops from 5 to 4
-        targetManagement.delete(List.of(running.get(4).getTarget().getId()));
-        // finish 3, report error on 1 → error=1/4=25% > 20%
+        // 3/5 SUCCESS, 1 DELETE -> 3/4 SUCCESS, 1/4 ERROR fulfill ErrorCondition >23% => Trigger ErrorAction#PAUSE
+        actionRepository.deleteById(running.get(4).getId());
         running.subList(0, 3).forEach(this::finishAction);
         reportError(running.get(3));
 
         rolloutHandler.handleAll();
 
-        // correct denominator=4: 1/4=25% > 20% → error fires → PAUSED
-        assertRollout(rollout, false, RolloutStatus.PAUSED, 1, 4);
-        assertGroup(group, false, RolloutGroupStatus.ERROR, 4);
+        assertGroup(groups.get(0), false, RolloutGroupStatus.ERROR, 4);
+        assertGroup(groups.get(1), false, RolloutGroupStatus.SCHEDULED, 5);
+        assertRollout(rollout, false, RolloutStatus.PAUSED, 2, 9);
     }
 
-    @SneakyThrows
-    @Test
-    void successConditionMetBeforeGroupFinishedTriggersNextGroup() {
-        // 10 targets → 2 groups of 5. Success threshold 60%: fires when 3 of 5 finish, while 2 still running.
-        final String targetPrefix = "sc1";
-        final DistributionSet ds = testdataFactory.createDistributionSetLocked("sc1Ds");
-        testdataFactory.createTargets(targetPrefix, 10);
+    private Rollout rolloutWith2Groups(
+            final String name, final String targetPrefix, final DistributionSet ds,
+            final String successCondition, final RolloutGroupSuccessAction successAction,
+            final String errorCondition) throws Exception {
+        return callAs(
+                withUser(name + "User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
+                () -> testdataFactory.createRolloutByVariables(name, name, 2,
+                        "controllerid==" + targetPrefix + "*", ds,
+                        successCondition, successAction, errorCondition, null, null, false, false));
+    }
 
-        final Rollout rollout = callAs(
-                withUser("sc1User", "READ_DISTRIBUTION_SET", "READ_TARGET", "READ_ROLLOUT", "CREATE_ROLLOUT"),
-                () -> testdataFactory.createRolloutByVariables("sc1Rollout", "sc1", 2,
-                        "controllerid==" + targetPrefix + "*", ds, "60", "90", null, null, false));
-
-        final List<RolloutGroup> groups = rolloutGroupManagement.findByRollout(
+    private List<RolloutGroup> getGroups(final Rollout rollout) {
+        return rolloutGroupManagement.findByRollout(
                 rollout.getId(), new OffsetBasedPageRequest(0, 10, Sort.by(Direction.ASC, "id"))).getContent();
-
-        rolloutManagement.start(rollout.getId());
-        rolloutHandler.handleAll();
-
-        // only group 1 is RUNNING — 5 actions
-        final List<JpaAction> group1Actions = assertAndGetRunning(rollout, 5).getContent();
-
-        // finish 3 of 5 → 60% meets 60% success threshold; 2 still RUNNING in group 1
-        group1Actions.subList(0, 3).forEach(this::finishAction);
-
-        rolloutHandler.handleAll();
-
-        // success condition met (3/5 = 60%) before group 1 finishes → NEXTGROUP fires → group 2 starts
-        // group 1 stays RUNNING (2 actions still in progress, group not complete)
-        assertGroup(groups.get(0), false, RolloutGroupStatus.RUNNING, 5);
-        assertGroup(groups.get(1), false, RolloutGroupStatus.RUNNING, 5);
-        assertRollout(rollout, false, RolloutStatus.RUNNING, 2, 10);
     }
 
     private void setCanceled(final JpaAction action) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutManagementTest.java
@@ -1004,10 +1004,9 @@ class RolloutManagementTest extends AbstractJpaIntegrationTest {
 
         rolloutOne = reloadRollout(rolloutOne);
         changeStatusForRunningActions(rolloutOne, Status.ERROR, 2);
-        changeStatusForRunningActions(rolloutOne, Status.FINISHED, 3);
+        changeStatusForRunningActions(rolloutOne, Status.FINISHED, 1);
         rolloutHandler.handleAll();
-        // verify: 40% error and 60% finished -> should not move to next group
-        // because successCondition 80%
+        // verify: 2 RUNNING remain → group not complete → success action not triggered regardless of thresholds
         final List<RolloutGroup> rolloutGruops = rolloutGroupManagement.findByRollout(rolloutOne.getId(), PAGE)
                 .getContent();
         final Map<TotalTargetCountStatus.Status, Long> expectedTargetCountStatus = createInitStatusMap();
@@ -1675,11 +1674,11 @@ class RolloutManagementTest extends AbstractJpaIntegrationTest {
         rolloutHandler.handleAll();
         assertRolloutGroup(rolloutGroupIds.get(0), RolloutGroupStatus.FINISHED, true, amountTargetsInGroup1,
                 Status.CANCELED);
-        assertRolloutGroup(rolloutGroupIds.get(1), RolloutGroupStatus.SCHEDULED, false, amountTargetsInGroup2,
-                Status.SCHEDULED);
+        // group 1 complete (all CANCELED) → success action fires immediately → group 2 starts in same cycle
+        assertRolloutGroup(rolloutGroupIds.get(1), RolloutGroupStatus.RUNNING, false, amountTargetsInGroup2,
+                Status.RUNNING);
 
-        // verify actions of second rule are directly in RUNNING state, since
-        // confirmation is not required for this group
+        // verify state is stable across another scheduler cycle
         rolloutHandler.handleAll();
         assertRolloutGroup(rolloutGroupIds.get(0), RolloutGroupStatus.FINISHED, true, amountTargetsInGroup1,
                 Status.CANCELED);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorConditionTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorConditionTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.repository.jpa.rollout.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.hawkbit.repository.jpa.repository.ActionRepository;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ThresholdRolloutGroupErrorConditionTest {
+
+    private static final long ROLLOUT_ID = 1L;
+    private static final long GROUP_ID = 10L;
+    private static final List<Action.Status> ERROR_STATUSES = List.of(Action.Status.ERROR, Action.Status.CANCELED);
+
+    @Mock
+    private ActionRepository actionRepository;
+    @Mock
+    private Rollout rollout;
+    @Mock
+    private RolloutGroup rolloutGroup;
+
+    private ThresholdRolloutGroupErrorCondition condition;
+
+    @BeforeEach
+    void setUp() {
+        condition = new ThresholdRolloutGroupErrorCondition(actionRepository);
+        when(rollout.getId()).thenReturn(ROLLOUT_ID);
+        when(rolloutGroup.getId()).thenReturn(GROUP_ID);
+        when(rolloutGroup.getTotalTargets()).thenReturn(5);
+    }
+
+    @Test
+    void errorStatusExceedsThreshold() {
+        // 2 ERROR / 5 = 40% > 10%
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(2L);
+        assertThat(condition.eval(rollout, rolloutGroup, "10")).isTrue();
+    }
+
+    @Test
+    void canceledStatusExceedsThreshold() {
+        // Bug 3: 1 CANCELED / 5 = 20% > 10% must fire
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+        assertThat(condition.eval(rollout, rolloutGroup, "10")).isTrue();
+    }
+
+    @Test
+    void errorAndCanceledCombinedExceedThreshold() {
+        // 3 combined (ERROR+CANCELED) / 5 = 60% > 50%
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(3L);
+        assertThat(condition.eval(rollout, rolloutGroup, "50")).isTrue();
+    }
+
+    @Test
+    void canceledStatusBelowThreshold() {
+        // 1 CANCELED / 5 = 20% < 50%
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+        assertThat(condition.eval(rollout, rolloutGroup, "50")).isFalse();
+    }
+
+    @Test
+    void noErrorsOrCanceledDoesNotFire() {
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(0L);
+        assertThat(condition.eval(rollout, rolloutGroup, "10")).isFalse();
+    }
+
+    @Test
+    void exactlyAtThresholdDoesNotFire() {
+        // strict >: 1/5 = 20%, threshold=20% → not exceeded
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+        assertThat(condition.eval(rollout, rolloutGroup, "20")).isFalse();
+    }
+
+    @Test
+    void zeroTotalTargetsDoesNotFire() {
+        when(rolloutGroup.getTotalTargets()).thenReturn(0);
+        assertThat(condition.eval(rollout, rolloutGroup, "10")).isFalse();
+    }
+
+    @Test
+    void invalidThresholdExpressionDoesNotFire() {
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+        assertThat(condition.eval(rollout, rolloutGroup, "notANumber")).isFalse();
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorConditionTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupErrorConditionTest.java
@@ -12,8 +12,6 @@ package org.eclipse.hawkbit.repository.jpa.rollout.condition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-
 import org.eclipse.hawkbit.repository.jpa.repository.ActionRepository;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.Rollout;
@@ -29,7 +27,6 @@ class ThresholdRolloutGroupErrorConditionTest {
 
     private static final long ROLLOUT_ID = 1L;
     private static final long GROUP_ID = 10L;
-    private static final List<Action.Status> ERROR_STATUSES = List.of(Action.Status.ERROR, Action.Status.CANCELED);
 
     @Mock
     private ActionRepository actionRepository;
@@ -51,41 +48,27 @@ class ThresholdRolloutGroupErrorConditionTest {
     @Test
     void errorStatusExceedsThreshold() {
         // 2 ERROR / 5 = 40% > 10%
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(2L);
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.ERROR)).thenReturn(2L);
         assertThat(condition.eval(rollout, rolloutGroup, "10")).isTrue();
     }
 
     @Test
-    void canceledStatusExceedsThreshold() {
-        // Bug 3: 1 CANCELED / 5 = 20% > 10% must fire
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
-        assertThat(condition.eval(rollout, rolloutGroup, "10")).isTrue();
-    }
-
-    @Test
-    void errorAndCanceledCombinedExceedThreshold() {
-        // 3 combined (ERROR+CANCELED) / 5 = 60% > 50%
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(3L);
-        assertThat(condition.eval(rollout, rolloutGroup, "50")).isTrue();
-    }
-
-    @Test
-    void canceledStatusBelowThreshold() {
-        // 1 CANCELED / 5 = 20% < 50%
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+    void errorStatusBelowThreshold() {
+        // 1 ERROR / 5 = 20% < 50%
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.ERROR)).thenReturn(1L);
         assertThat(condition.eval(rollout, rolloutGroup, "50")).isFalse();
     }
 
     @Test
-    void noErrorsOrCanceledDoesNotFire() {
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(0L);
+    void noErrorsDoesNotFire() {
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.ERROR)).thenReturn(0L);
         assertThat(condition.eval(rollout, rolloutGroup, "10")).isFalse();
     }
 
     @Test
     void exactlyAtThresholdDoesNotFire() {
         // strict >: 1/5 = 20%, threshold=20% → not exceeded
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.ERROR)).thenReturn(1L);
         assertThat(condition.eval(rollout, rolloutGroup, "20")).isFalse();
     }
 
@@ -97,7 +80,7 @@ class ThresholdRolloutGroupErrorConditionTest {
 
     @Test
     void invalidThresholdExpressionDoesNotFire() {
-        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatusIn(ROLLOUT_ID, GROUP_ID, ERROR_STATUSES)).thenReturn(1L);
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.ERROR)).thenReturn(1L);
         assertThat(condition.eval(rollout, rolloutGroup, "notANumber")).isFalse();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupSuccessConditionTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rollout/condition/ThresholdRolloutGroupSuccessConditionTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.repository.jpa.rollout.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hawkbit.repository.jpa.repository.ActionRepository;
+import org.eclipse.hawkbit.repository.model.Action;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.RolloutGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class ThresholdRolloutGroupSuccessConditionTest {
+
+    private static final long ROLLOUT_ID = 1L;
+    private static final long GROUP_ID = 10L;
+
+    @Mock
+    private ActionRepository actionRepository;
+    @Mock
+    private Rollout rollout;
+    @Mock
+    private RolloutGroup rolloutGroup;
+
+    private ThresholdRolloutGroupSuccessCondition condition;
+
+    @BeforeEach
+    void setUp() {
+        condition = new ThresholdRolloutGroupSuccessCondition(actionRepository);
+        when(rollout.getId()).thenReturn(ROLLOUT_ID);
+        when(rolloutGroup.getId()).thenReturn(GROUP_ID);
+        when(rolloutGroup.getTotalTargets()).thenReturn(5);
+    }
+
+    @Test
+    void finishedRatioMeetsThreshold() {
+        // 4 FINISHED / 5 = 80% >= 80%
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.FINISHED)).thenReturn(4L);
+        assertThat(condition.eval(rollout, rolloutGroup, "80")).isTrue();
+    }
+
+    @Test
+    void finishedRatioBelowThreshold() {
+        // 3 FINISHED / 5 = 60% < 80%
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.FINISHED)).thenReturn(3L);
+        assertThat(condition.eval(rollout, rolloutGroup, "80")).isFalse();
+    }
+
+    @Test
+    void exactlyAtThresholdFires() {
+        // uses >=: 1/5 = 20%, threshold=20% → fires (contrast: error uses >)
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.FINISHED)).thenReturn(1L);
+        assertThat(condition.eval(rollout, rolloutGroup, "20")).isTrue();
+    }
+
+    @Test
+    void zeroTotalTargetsReturnsTrue() {
+        // opposite of error condition: no targets = group considered done
+        when(rolloutGroup.getTotalTargets()).thenReturn(0);
+        assertThat(condition.eval(rollout, rolloutGroup, "100")).isTrue();
+    }
+
+    @Test
+    void downloadOnlyUsesDownloadedStatus() {
+        when(rollout.getActionType()).thenReturn(Action.ActionType.DOWNLOAD_ONLY);
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.DOWNLOADED)).thenReturn(5L);
+        assertThat(condition.eval(rollout, rolloutGroup, "100")).isTrue();
+    }
+
+    @Test
+    void downloadOnlyDoesNotCountFinishedStatus() {
+        when(rollout.getActionType()).thenReturn(Action.ActionType.DOWNLOAD_ONLY);
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.DOWNLOADED)).thenReturn(0L);
+        assertThat(condition.eval(rollout, rolloutGroup, "100")).isFalse();
+    }
+
+    @Test
+    void noFinishedActionsDoesNotFire() {
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.FINISHED)).thenReturn(0L);
+        assertThat(condition.eval(rollout, rolloutGroup, "10")).isFalse();
+    }
+
+    @Test
+    void invalidThresholdExpressionReturnsFalse() {
+        when(actionRepository.countByRolloutIdAndRolloutGroupIdAndStatus(ROLLOUT_ID, GROUP_ID, Action.Status.FINISHED)).thenReturn(5L);
+        assertThat(condition.eval(rollout, rolloutGroup, "notANumber")).isFalse();
+    }
+}


### PR DESCRIPTION


### Error/Success Conditions skipped if no match, still group marked as finish and nextGroup is triggered

There is a bug in our Rollout  handling whenever Error/Success conditions are not met - and thus not executed, but All Actions have finished - group is marked as finished which leads to.

Error/Success Condition is not executed
Next scheduler run just starts nextGroup
 

Proposal:

If neither Error nor Success Condition/Action triggered but all Actions finished - execute success Action (no change in behavior, only fixes the issue when Success Action is PAUSE) - Only if Error Condition is met then mark group in ERROR state - otherwise consider it success (success action is triggered whenever either Success Condition or Group has finished)

--- 


### If Action is deleted group percentage is not updated correctly -
we count assigned Targets
we count finished Actions
if we delete Actions, but target remain - percentage calculations is broken and could never be met in some cases (i.e. 100% success, on 5 targets, 5 Actions - but delete an Action -> 5 Targets with, 4 Success Actions -> this in theory is 100%, but not handled)
 

Proposal:

**Option 1:** Do nothing - this seems a corner case - Usually if user wants should "force-quit" the Action, not delete it.
**Option 2: Chosen** Count Actions not target (i.e. like Dynamic groups - else condition below)
Current impl:

```
private long countTargetsFrom(final JpaRolloutGroup rolloutGroup) {
    if (rolloutGroup.isDynamic()) {
        return countByActionsInRolloutGroup(rolloutGroup.getId());
    } else {
        return rolloutGroupManagement.countTargetsOfRolloutsGroup(rolloutGroup.getId());
    }
} 
```


---


### Cancel result is not mapped to Error nor Success

Same percentage break whenever we have Cancelled Action. It is not considered neither as Error nor Success. This could also break Error/Success evaluation - i.e. skip Actions, triggerNext group
In case we have 5 Targets, 4 Actions Success, 1 Action Cancelled. on 

Success condition 100%, with PAUSE Success ACTION -> Success action is never executed as condition is not met, but yet triggerNextGroup 

- Ignore Cancel as it is neither Error nor Success -> it will not be calculated in Error/Success Condition.