### PR TITLE
Add support for soft deleted listing in Rollouts full representation

### DIFF
--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResource.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResource.java
@@ -83,16 +83,16 @@ public class MgmtRolloutResource implements MgmtRolloutRestApi {
             final String representationModeParam, final MgmtSoftDeletedMode softDeletedModeParam) {
         final Pageable pageable = PagingUtility.toPageable(pagingOffsetParam, pagingLimitParam, sanitizeRolloutSortParam(sortParam));
         final boolean isFullMode = parseRepresentationMode(representationModeParam) == MgmtRepresentationMode.FULL;
+        final SoftDeletedMode softDeletedMode = SoftDeletedMode.valueOf(softDeletedModeParam.name());
 
         final Page<Rollout> rollouts;
         final List<MgmtRolloutResponseBody> rest;
         if (isFullMode) {
             rollouts = rsqlParam == null
-                    ? rolloutManagement.findAllWithDetailedStatus(false, pageable)
-                    : rolloutManagement.findByRsqlWithDetailedStatus(rsqlParam, false, pageable);
+                    ? rolloutManagement.findAllWithDetailedStatus(softDeletedMode, pageable)
+                    : rolloutManagement.findByRsqlWithDetailedStatus(rsqlParam, softDeletedMode, pageable);
             rest = MgmtRolloutMapper.toResponseRolloutWithDetails(rollouts.getContent());
         } else {
-            final SoftDeletedMode softDeletedMode = SoftDeletedMode.valueOf(softDeletedModeParam.name());
             rollouts = rsqlParam == null
                     ? rolloutManagement.findAll(softDeletedMode, pageable)
                     : rolloutManagement.findByRsql(rsqlParam, softDeletedMode, pageable);

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtRolloutResourceTest.java
@@ -1600,6 +1600,108 @@ class MgmtRolloutResourceTest extends AbstractManagementApiIntegrationTest {
     }
 
     @Test
+    void getFullRepresentationRolloutsFilteredBySoftDeletedMode() throws Exception {
+        testdataFactory.createTargets(20, "rolloutFullSd", "rolloutFullSd");
+        final DistributionSet dsA = testdataFactory.createDistributionSet("fullSdDs");
+
+        final Rollout rollout1 = createRollout("activeFullRollout", 4, dsA, "controllerId==rolloutFullSd*");
+        final Rollout rollout2 = createRollout("toDeleteFullRollout", 4, dsA, "controllerId==rolloutFullSd*");
+
+        // start and soft-delete rollout2
+        rolloutManagement.start(rollout2.getId());
+        rolloutHandler.handleAll();
+        rolloutManagement.delete(rollout2.getId());
+        rolloutHandler.handleAll();
+
+        // default (exclude_soft_deleted) in full mode — only active rollout
+        mvc.perform(get("/rest/v1/rollouts")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, "full")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.total", equalTo(1)))
+                .andExpect(jsonPath("content[0].name", equalTo(rollout1.getName())))
+                .andExpect(jsonPath("content[0].deleted", equalTo(false)))
+                .andExpect(jsonPath("content[0].totalTargetsPerStatus").exists());
+
+        // only_soft_deleted in full mode — only deleted rollout
+        mvc.perform(get("/rest/v1/rollouts")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, "full")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_LIST_SOFT_DELETED_MODE, "ONLY_SOFT_DELETED")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.total", equalTo(1)))
+                .andExpect(jsonPath("content[0].name", equalTo(rollout2.getName())))
+                .andExpect(jsonPath("content[0].deleted", equalTo(true)))
+                .andExpect(jsonPath("content[0].totalTargetsPerStatus").exists());
+
+        // include_soft_deleted in full mode — both rollouts
+        mvc.perform(get("/rest/v1/rollouts")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, "full")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_LIST_SOFT_DELETED_MODE, "INCLUDE_SOFT_DELETED")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.total", equalTo(2)));
+    }
+
+    @Test
+    void getFullRepresentationRolloutsFilteredBySoftDeletedModeWithRsql() throws Exception {
+        testdataFactory.createTargets(20, "rolloutFullRsql", "rolloutFullRsql");
+        final DistributionSet dsA = testdataFactory.createDistributionSet("fullRsqlDs");
+
+        final Rollout rollout1 = createRollout("fullRsqlActive", 4, dsA, "controllerId==rolloutFullRsql*");
+        final Rollout rollout2 = createRollout("fullRsqlDeleted", 4, dsA, "controllerId==rolloutFullRsql*");
+
+        // start and soft-delete rollout2
+        rolloutManagement.start(rollout2.getId());
+        rolloutHandler.handleAll();
+        rolloutManagement.delete(rollout2.getId());
+        rolloutHandler.handleAll();
+
+        // rsql + only_soft_deleted in full mode — find deleted rollout by name
+        mvc.perform(get("/rest/v1/rollouts")
+                        .param("q", "name==fullRsqlDeleted")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, "full")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_LIST_SOFT_DELETED_MODE, "ONLY_SOFT_DELETED")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.total", equalTo(1)))
+                .andExpect(jsonPath("content[0].name", equalTo(rollout2.getName())))
+                .andExpect(jsonPath("content[0].deleted", equalTo(true)))
+                .andExpect(jsonPath("content[0].totalTargetsPerStatus").exists());
+
+        // rsql + default (exclude_soft_deleted) in full mode — deleted rollout not found
+        mvc.perform(get("/rest/v1/rollouts")
+                        .param("q", "name==fullRsqlDeleted")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, "full")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.total", equalTo(0)));
+
+        // rsql + include_soft_deleted in full mode — both visible, filter by name narrows to one
+        mvc.perform(get("/rest/v1/rollouts")
+                        .param("q", "name==fullRsqlActive")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_REPRESENTATION_MODE, "full")
+                        .param(MgmtRestConstants.REQUEST_PARAMETER_LIST_SOFT_DELETED_MODE, "INCLUDE_SOFT_DELETED")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.total", equalTo(1)))
+                .andExpect(jsonPath("content[0].name", equalTo(rollout1.getName())))
+                .andExpect(jsonPath("content[0].totalTargetsPerStatus").exists());
+    }
+
+    @Test
     void stopRunningRollout() throws Exception {
         final Rollout rollout = testdataFactory.createAndStartRollout();
         mvc.perform(post("/rest/v1/rollouts/{rolloutId}/stop", rollout.getId()))

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -177,12 +177,12 @@ public interface RolloutManagement extends PermissionSupport {
     /**
      * Get count of targets in different status in rollout.
      *
-     * @param deleted flag if deleted rollouts should be included
+     * @param softDeletedMode the filter defining which rollouts to return based on their soft-deleted status
      * @param pageable the page request to sort and limit the result
      * @return a list of rollouts with details of targets count for different statuses
      */
     @PreAuthorize(SpringEvalExpressions.HAS_READ_REPOSITORY)
-    Page<Rollout> findAllWithDetailedStatus(boolean deleted, @NotNull Pageable pageable);
+    Page<Rollout> findAllWithDetailedStatus(SoftDeletedMode softDeletedMode, @NotNull Pageable pageable);
 
     /**
      * Retrieves all rollouts found by the given specification.
@@ -216,12 +216,12 @@ public interface RolloutManagement extends PermissionSupport {
      * Finds rollouts by given text in name or description.
      *
      * @param rsql search text which matches name or description of rollout
-     * @param deleted flag if deleted rollouts should be included
+     * @param softDeletedMode the filter defining which rollouts to return based on their soft-deleted status
      * @param pageable the page request to sort and limit the result
      * @return the founded rollout or {@code null} if rollout with given ID does not exist
      */
     @PreAuthorize(SpringEvalExpressions.HAS_READ_REPOSITORY)
-    Page<Rollout> findByRsqlWithDetailedStatus(@NotEmpty String rsql, boolean deleted, @NotNull Pageable pageable);
+    Page<Rollout> findByRsqlWithDetailedStatus(@NotEmpty String rsql, SoftDeletedMode softDeletedMode, @NotNull Pageable pageable);
 
     /**
      * Find rollouts which are still active and needs to be handled.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaRolloutManagement.java
@@ -268,21 +268,15 @@ public class JpaRolloutManagement implements RolloutManagement {
     }
 
     @Override
-    public Page<Rollout> findAll(final SoftDeletedMode softDeletedMode, Pageable pageable) {
-        return switch (softDeletedMode) {
-            case EXCLUDE_SOFT_DELETED -> JpaManagementHelper.convertPage(
-                    rolloutRepository.findAll(RolloutSpecification.isDeleted(false, pageable.getSort()), pageable), pageable);
-            case ONLY_SOFT_DELETED -> JpaManagementHelper.convertPage(
-                    rolloutRepository.findAll(RolloutSpecification.isDeleted(true, pageable.getSort()), pageable), pageable);
-            case INCLUDE_SOFT_DELETED -> JpaManagementHelper.convertPage(
-                    rolloutRepository.findAll(Specification.unrestricted(), pageable), pageable);
-        };
+    public Page<Rollout> findAll(final SoftDeletedMode softDeletedMode, final Pageable pageable) {
+        return JpaManagementHelper.convertPage(
+                rolloutRepository.findAll(softDeleteSpec(softDeletedMode, pageable.getSort()), pageable), pageable);
     }
 
     @Override
-    public Page<Rollout> findAllWithDetailedStatus(final boolean deleted, final Pageable pageable) {
+    public Page<Rollout> findAllWithDetailedStatus(final SoftDeletedMode softDeletedMode, final Pageable pageable) {
         return appendStatusDetails(JpaManagementHelper.convertPage(
-                rolloutRepository.findAll(RolloutSpecification.isDeleted(deleted, pageable.getSort()), JpaRollout_.GRAPH_ROLLOUT_DS, pageable),
+                rolloutRepository.findAll(softDeleteSpec(softDeletedMode, pageable.getSort()), JpaRollout_.GRAPH_ROLLOUT_DS, pageable),
                 pageable));
     }
 
@@ -295,27 +289,20 @@ public class JpaRolloutManagement implements RolloutManagement {
     }
 
     @Override
-    public Page<Rollout> findByRsql(String rsql, SoftDeletedMode softDeletedMode, Pageable pageable) {
-        final Specification<JpaRollout> rsqlSpec = QLSupport.getInstance().buildSpec(rsql, RolloutFields.class);
-
-        if (softDeletedMode != SoftDeletedMode.INCLUDE_SOFT_DELETED) {
-            final Specification<JpaRollout> deletedSpec = RolloutSpecification.isDeleted(
-                    softDeletedMode == SoftDeletedMode.ONLY_SOFT_DELETED, pageable.getSort());
-            return JpaManagementHelper.convertPage(
-                    rolloutRepository.findAll(JpaManagementHelper.combineWithAnd(List.of(rsqlSpec, deletedSpec)), pageable), pageable);
-        } else {
-            return JpaManagementHelper.convertPage(rolloutRepository.findAll(rsqlSpec, pageable), pageable);
-
-        }
+    public Page<Rollout> findByRsql(final String rsql, final SoftDeletedMode softDeletedMode, final Pageable pageable) {
+        final Specification<JpaRollout> spec = JpaManagementHelper.combineWithAnd(List.of(
+                QLSupport.getInstance().buildSpec(rsql, RolloutFields.class),
+                softDeleteSpec(softDeletedMode, pageable.getSort())));
+        return JpaManagementHelper.convertPage(rolloutRepository.findAll(spec, pageable), pageable);
     }
 
     @Override
-    public Page<Rollout> findByRsqlWithDetailedStatus(final String rsql, final boolean deleted, final Pageable pageable) {
-        final List<Specification<JpaRollout>> specList = List.of(
+    public Page<Rollout> findByRsqlWithDetailedStatus(final String rsql, final SoftDeletedMode softDeletedMode, final Pageable pageable) {
+        final Specification<JpaRollout> spec = JpaManagementHelper.combineWithAnd(List.of(
                 QLSupport.getInstance().buildSpec(rsql, RolloutFields.class),
-                RolloutSpecification.isDeleted(deleted, pageable.getSort()));
+                softDeleteSpec(softDeletedMode, pageable.getSort())));
         return appendStatusDetails(JpaManagementHelper.convertPage(
-                rolloutRepository.findAll(JpaManagementHelper.combineWithAnd(specList), JpaRollout_.GRAPH_ROLLOUT_DS, pageable), pageable));
+                rolloutRepository.findAll(spec, JpaRollout_.GRAPH_ROLLOUT_DS, pageable), pageable));
     }
 
     @Override
@@ -675,6 +662,12 @@ public class JpaRolloutManagement implements RolloutManagement {
             });
         }
         return rollouts;
+    }
+
+    private static Specification<JpaRollout> softDeleteSpec(final SoftDeletedMode mode, final Sort sort) {
+        return mode == SoftDeletedMode.INCLUDE_SOFT_DELETED
+                ? Specification.unrestricted()
+                : RolloutSpecification.isDeleted(mode == SoftDeletedMode.ONLY_SOFT_DELETED, sort);
     }
 
     private static void validateDs(final Create rollout) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/RolloutManagementTest.java
@@ -34,6 +34,7 @@ import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
 import org.eclipse.hawkbit.repository.RolloutManagement.Create;
 import org.eclipse.hawkbit.repository.RolloutManagement.GroupCreate;
 import org.eclipse.hawkbit.repository.RolloutManagement.Update;
+import org.eclipse.hawkbit.repository.SoftDeletedMode;
 import org.eclipse.hawkbit.repository.event.remote.RolloutDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.RolloutGroupDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.TargetAssignDistributionSetEvent;
@@ -1086,7 +1087,7 @@ class RolloutManagementTest extends AbstractJpaIntegrationTest {
         rolloutHandler.handleAll();
 
         final Slice<Rollout> rolloutPage = rolloutManagement
-                .findAllWithDetailedStatus(false, new OffsetBasedPageRequest(0, 100, Sort.by(Direction.ASC, "name")));
+                .findAllWithDetailedStatus(SoftDeletedMode.EXCLUDE_SOFT_DELETED, new OffsetBasedPageRequest(0, 100, Sort.by(Direction.ASC, "name")));
         final List<Rollout> rolloutList = rolloutPage.getContent();
 
         // validate rolloutA -> 6 running and 6 ready
@@ -1153,7 +1154,7 @@ class RolloutManagementTest extends AbstractJpaIntegrationTest {
         }
 
         final Slice<Rollout> rollout = rolloutManagement.findByRsqlWithDetailedStatus(
-                "name==Rollout*", false, new OffsetBasedPageRequest(0, 100, Sort.by(Direction.ASC, "name")));
+                "name==Rollout*", SoftDeletedMode.EXCLUDE_SOFT_DELETED, new OffsetBasedPageRequest(0, 100, Sort.by(Direction.ASC, "name")));
         final List<Rollout> rolloutList = rollout.getContent();
         assertThat(rolloutList).hasSize(5);
         int i = 1;


### PR DESCRIPTION
  - Extract softDeleteSpec helper in JpaRolloutManagement to eliminate duplicated SoftDeletedMode → Specification translation across four methods
  - Enable soft-deleted rollout listing in full representation mode (previously hardcoded to false)
  - Add REST-level tests for full representation mode with all three SoftDeletedMode values, with and without RSQL