### PR TITLE
Fix Action History View

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/component/TargetActionsHistory.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/component/TargetActionsHistory.java
@@ -86,10 +86,10 @@ public final class TargetActionsHistory extends Grid<TargetActionsHistory.Action
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
+        getElement().executeJs("if (!this.$connector && window.Vaadin && Vaadin.Flow && Vaadin.Flow.gridConnector) { Vaadin.Flow.gridConnector.initLazy(this); }");
         List<ActionStatusEntry> actionStatusEntries = fetchActions();
         setItems(actionStatusEntries);
         actionStatusEntries.stream().findFirst().ifPresentOrElse(e -> {
-            // select first action in the list by default
             asSingleSelect().setValue(e);
             actionStepsGrid.setActionId(e.action.getId());
         }, () -> actionStepsGrid.setActionId(null));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/component/TargetActionsHistory.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/component/TargetActionsHistory.java
@@ -86,7 +86,9 @@ public final class TargetActionsHistory extends Grid<TargetActionsHistory.Action
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
+        // TODO: it is a bug in vaadin, reported at 02.07.2026. To remove when fixed
         getElement().executeJs("if (!this.$connector && window.Vaadin && Vaadin.Flow && Vaadin.Flow.gridConnector) { Vaadin.Flow.gridConnector.initLazy(this); }");
+
         List<ActionStatusEntry> actionStatusEntries = fetchActions();
         setItems(actionStatusEntries);
         actionStatusEntries.stream().findFirst().ifPresentOrElse(e -> {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
@@ -355,14 +355,14 @@ public final class TargetView extends TableView<TargetView.TargetWithDs, String>
 
         private TargetDetailedView(final HawkbitMgmtClient hawkbitClient) {
             final TabSheet tabSheet = new TabSheet();
-            tabSheet.setWidthFull();
+            tabSheet.setSizeFull();
             targetId = new Span();
             targetDetails = new TargetDetails(hawkbitClient);
             targetAssignedInstalled = new TargetAssignedInstalled(hawkbitClient);
             targetTags = new TargetTags(hawkbitClient);
             targetMetadata = new TargetMetadata(hawkbitClient);
             targetActionsHistoryLayout = new TargetActionsHistoryLayout(hawkbitClient);
-            setWidthFull();
+            setSizeFull();
 
             add(targetId);
             tabSheet.add("Details", targetDetails);
@@ -370,7 +370,7 @@ public final class TargetView extends TableView<TargetView.TargetWithDs, String>
             tabSheet.add("Tags", targetTags);
             tabSheet.add("Metadata", targetMetadata);
             tabSheet.add("Action History", targetActionsHistoryLayout);
-            add(tabSheet);
+            addAndExpand(tabSheet);
         }
 
         private void setItem(final MgmtTarget target) {
@@ -672,17 +672,40 @@ public final class TargetView extends TableView<TargetView.TargetWithDs, String>
         @Serial
         private static final long serialVersionUID = 1L;
 
-        private final TargetActionsHistory targetActionsHistory;
+        private final transient HawkbitMgmtClient hawkbitMgmtClient;
+        private TargetActionsHistory targetActionsHistory;
+        private transient MgmtTarget pendingTarget;
 
         public TargetActionsHistoryLayout(HawkbitMgmtClient hawkbitMgmtClient) {
-            ActionStepsGrid actionStepsGrid = new ActionStepsGrid(hawkbitMgmtClient);
-            targetActionsHistory = new TargetActionsHistory(hawkbitMgmtClient, actionStepsGrid);
-            add(targetActionsHistory);
-            add(actionStepsGrid);
+            this.hawkbitMgmtClient = hawkbitMgmtClient;
+            setSizeFull();
+            setMinHeight("60vh");
+            setPadding(false);
+            setSpacing(false);
+        }
+
+        @Override
+        protected void onAttach(AttachEvent attachEvent) {
+            if (targetActionsHistory == null) {
+                ActionStepsGrid actionStepsGrid = new ActionStepsGrid(hawkbitMgmtClient);
+                targetActionsHistory = new TargetActionsHistory(hawkbitMgmtClient, actionStepsGrid);
+                targetActionsHistory.setSizeFull();
+                targetActionsHistory.setMinHeight("25vh");
+                actionStepsGrid.setSizeFull();
+                actionStepsGrid.setMinHeight("25vh");
+                if (pendingTarget != null) {
+                    targetActionsHistory.setItem(pendingTarget);
+                    actionStepsGrid.setTarget(pendingTarget);
+                }
+                addAndExpand(targetActionsHistory, actionStepsGrid);
+            }
         }
 
         public void setItem(MgmtTarget target) {
-            targetActionsHistory.setItem(target);
+            this.pendingTarget = target;
+            if (targetActionsHistory != null) {
+                targetActionsHistory.setItem(target);
+            }
         }
 
         public static class ActionStepsGrid extends Grid<ActionStepsGrid.ActionStepEntry> {
@@ -717,6 +740,7 @@ public final class TargetView extends TableView<TargetView.TargetWithDs, String>
 
             @Override
             protected void onAttach(AttachEvent attachEvent) {
+                getElement().executeJs("if (!this.$connector && window.Vaadin && Vaadin.Flow && Vaadin.Flow.gridConnector) { Vaadin.Flow.gridConnector.initLazy(this); }");
                 setItems(fetchActionSteps());
             }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetView.java
@@ -740,7 +740,9 @@ public final class TargetView extends TableView<TargetView.TargetWithDs, String>
 
             @Override
             protected void onAttach(AttachEvent attachEvent) {
+                // TODO: it is a bug in vaadin, reported at 02.07.2026. To remove when fixed
                 getElement().executeJs("if (!this.$connector && window.Vaadin && Vaadin.Flow && Vaadin.Flow.gridConnector) { Vaadin.Flow.gridConnector.initLazy(this); }");
+
                 setItems(fetchActionSteps());
             }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/util/TableView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/util/TableView.java
@@ -81,6 +81,8 @@ public class TableView<T, ID> extends Div implements Constants, BeforeEnterObser
         splitLayout.setSplitterPosition(100);
         splitLayout.addToPrimary(selectionGrid);
         detailsPanel = new Div();
+        detailsPanel.setSizeFull();
+        detailsPanel.getStyle().set("display", "flex").set("flex-direction", "column").set("min-height", "0");
 
         if (detailsButtonHandler != null) {
             ComponentRenderer<Button, T> renderer = new ComponentRenderer<>(renderDetailsButton(detailsButtonHandler));


### PR DESCRIPTION
Action History View per target was not rendered due to bug in Vaadin (reported here - https://github.com/vaadin/flow-components/issues/9662). 

Perform a workaround with Force-init the connector on attach.