### PR TITLE
Low-level auto-assignment approval

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetFilterQueryManagement.java
@@ -94,7 +94,7 @@ public interface TargetFilterQueryManagement<T extends TargetFilterQuery>
      * @return the page with the found {@link TargetFilterQuery}s
      */
     @PreAuthorize(SpringEvalExpressions.HAS_READ_REPOSITORY)
-    Slice<TargetFilterQuery> findWithAutoAssignDS(@NotNull Pageable pageable);
+    Slice<TargetFilterQuery> findWithActiveAutoAssignDS(@NotNull Pageable pageable);
 
     /**
      * Updates the auto assign settings of an {@link TargetFilterQuery}.
@@ -123,6 +123,9 @@ public interface TargetFilterQueryManagement<T extends TargetFilterQuery>
      */
     @PreAuthorize(SpringEvalExpressions.HAS_UPDATE_REPOSITORY)
     void cancelAutoAssignmentForDistributionSet(long setId);
+
+    @PreAuthorize(SpringEvalExpressions.HAS_UPDATE_REPOSITORY)
+    TargetFilterQuery start(final long targetFilterQueryId);
 
     @SuperBuilder
     @Getter
@@ -176,6 +179,13 @@ public interface TargetFilterQueryManagement<T extends TargetFilterQuery>
         private final long targetFilterId;
         private Long dsId;
         private ActionType actionType;
+        private Long startAt;
+
+        private TargetFilterQuery.AutoAssignStatus autoAssignStatus;
+        @Size(min = 1, max = TargetFilterQuery.APPROVED_BY_MAX_SIZE)
+        private String approvalDecidedBy;
+        @Size(max = TargetFilterQuery.APPROVAL_REMARK_MAX_SIZE)
+        private String approvalRemark;
 
         @Min(Action.WEIGHT_MIN)
         @Max(Action.WEIGHT_MAX)
@@ -211,6 +221,53 @@ public interface TargetFilterQueryManagement<T extends TargetFilterQuery>
          */
         public AutoAssignDistributionSetUpdate actionType(final ActionType actionType) {
             this.actionType = actionType;
+            return this;
+        }
+
+        /**
+         *
+         * Specify a timestamp when the auto assignment should be started automatically
+         *
+         * @param startAt time in milliseconds
+         * @return updated builder instance
+         */
+        public AutoAssignDistributionSetUpdate setStartAt(Long startAt) {
+            this.startAt = startAt;
+            return this;
+        }
+
+        /**
+         *
+         * Specify the status of the auto assignment
+         *
+         * @param autoAssignStatus status of the auto assignment
+         * @return updated builder instance
+         */
+        public AutoAssignDistributionSetUpdate setAutoAssignStatus(TargetFilterQuery.AutoAssignStatus autoAssignStatus) {
+            this.autoAssignStatus = autoAssignStatus;
+            return this;
+        }
+
+        /**
+         *
+         * Specify a user that approved or denied the auto assignment
+         *
+         * @param approvalDecidedBy username of the approving/denying user
+         * @return updated builder instance
+         */
+        public AutoAssignDistributionSetUpdate setApprovalDecidedBy(String approvalDecidedBy) {
+            this.approvalDecidedBy = approvalDecidedBy;
+            return this;
+        }
+
+        /**
+         * Specify an additional note on approval/denial decision
+         *
+         * @param approvalRemark the note
+         * @return updated builder instance
+         */
+        public AutoAssignDistributionSetUpdate setApprovalRemark(String approvalRemark) {
+            this.approvalRemark = approvalRemark;
             return this;
         }
 

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TargetFilterQuery.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TargetFilterQuery.java
@@ -47,6 +47,15 @@ public interface TargetFilterQuery extends TenantAwareBaseEntity {
     int QUERY_MAX_SIZE = 1024;
 
     /**
+     * Maximum length of author name.
+     */
+    int APPROVED_BY_MAX_SIZE = 64;
+
+    /**
+     * Maximum length on comment regarding approval decision.
+     */
+    int APPROVAL_REMARK_MAX_SIZE = 255;
+    /**
      * Maximum length of access control context.
      */
     int ACCESS_CONTROL_CONTEXT_MAX_SIZE = 32768;
@@ -78,6 +87,26 @@ public interface TargetFilterQuery extends TenantAwareBaseEntity {
     ActionType getAutoAssignActionType();
 
     /**
+     * @return Timestamp when the auto assignment should be started automatically. Can be null.
+     */
+    Long getStartAt();
+
+    /**
+     * @return status of the auto assignment
+     */
+    AutoAssignStatus getAutoAssignStatus();
+
+    /**
+     * @return user that approved or denied the auto assignment
+     */
+    String getApprovalDecidedBy();
+
+    /**
+     * @return additional note on approval/denial decision.
+     */
+    String getApprovalRemark();
+
+    /**
      * @return the weight of the {@link Action}s created during an auto assignment.
      */
     Optional<Integer> getAutoAssignWeight();
@@ -98,4 +127,35 @@ public interface TargetFilterQuery extends TenantAwareBaseEntity {
      * performing the auto-assignment by the scheduler
      */
     Optional<String> getAccessControlContext();
+
+    /**
+     * State machine for an auto assignment
+     */
+    enum AutoAssignStatus {
+
+        /**
+         * Auto assignment needs to be approved
+         */
+        WAITING_FOR_APPROVAL,
+
+        /**
+         * Auto assignment is denied. Cannot be started
+         */
+        APPROVAL_DENIED,
+
+        /**
+         * Auto assignment is ready to start
+         */
+        READY,
+
+        /**
+         * Auto assignment has been paused
+         */
+        PAUSED,
+
+        /**
+         * Auto assignment is running
+         */
+        RUNNING
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
@@ -101,6 +101,10 @@ public class TenantConfigurationProperties {
          */
         public static final String ROLLOUT_APPROVAL_ENABLED = "rollout.approval.enabled";
         /**
+         * Represents setting if approval for an auto assignment is needed.
+         */
+        public static final String AUTO_ASSIGNMENT_APPROVAL_ENABLED = "auto.assignment.approval.enabled";
+        /**
          * Repository on autoclose mode instead of canceling in case of new Distribution Set assignment over active actions.
          */
         public static final String REPOSITORY_ACTIONS_AUTOCLOSE_ENABLED = "repository.actions.autoclose.enabled";

--- a/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
@@ -73,6 +73,10 @@ hawkbit.server.tenant.configuration.rollout-approval-enabled.keyName=rollout.app
 hawkbit.server.tenant.configuration.rollout-approval-enabled.defaultValue=false
 hawkbit.server.tenant.configuration.rollout-approval-enabled.dataType=java.lang.Boolean
 
+hawkbit.server.tenant.configuration.auto-assignment-approval-enabled.keyName=auto.assignment.approval.enabled
+hawkbit.server.tenant.configuration.auto-assignment-approval-enabled.defaultValue=false
+hawkbit.server.tenant.configuration.auto-assignment-approval-enabled.dataType=java.lang.Boolean
+
 hawkbit.server.tenant.configuration.action-cleanup-auto-expiry.keyName=action.cleanup.auto.expiry
 # in millis, default: -1 (disabled), e.g. for 30 days set it to 2592000000
 hawkbit.server.tenant.configuration.action-cleanup-auto-expiry.defaultValue=-1

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/H2/V1_20_3__auto_assignment_approval__H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/H2/V1_20_3__auto_assignment_approval__H2.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sp_target_filter_query ADD COLUMN auto_assign_status INTEGER;
+ALTER TABLE sp_target_filter_query ADD COLUMN start_at BIGINT;
+ALTER TABLE sp_target_filter_query ADD COLUMN approval_decided_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query ADD COLUMN approval_remark VARCHAR(255);
+UPDATE sp_target_filter_query SET auto_assign_status = 4, start_at = last_modified_at WHERE auto_assign_distribution_set IS NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/MYSQL/V1_20_3__auto_assignment_approval__MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/MYSQL/V1_20_3__auto_assignment_approval__MYSQL.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sp_target_filter_query ADD COLUMN auto_assign_status INTEGER;
+ALTER TABLE sp_target_filter_query ADD COLUMN start_at BIGINT;
+ALTER TABLE sp_target_filter_query ADD COLUMN approval_decided_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query ADD COLUMN approval_remark VARCHAR(255);
+UPDATE sp_target_filter_query SET auto_assign_status = 4, start_at = last_modified_at WHERE auto_assign_distribution_set IS NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/POSTGRESQL/V1_20_3__auto_assignment_approval__POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa-flyway/src/main/resources/db/migration/POSTGRESQL/V1_20_3__auto_assignment_approval__POSTGRESQL.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sp_target_filter_query ADD COLUMN auto_assign_status INTEGER;
+ALTER TABLE sp_target_filter_query ADD COLUMN start_at BIGINT;
+ALTER TABLE sp_target_filter_query ADD COLUMN approval_decided_by VARCHAR(64);
+ALTER TABLE sp_target_filter_query ADD COLUMN approval_remark VARCHAR(255);
+UPDATE sp_target_filter_query SET auto_assign_status = 4, start_at = last_modified_at WHERE auto_assign_distribution_set IS NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/AbstractJpaRepositoryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/AbstractJpaRepositoryManagement.java
@@ -398,7 +398,7 @@ abstract class AbstractJpaRepositoryManagement<T extends AbstractJpaBaseEntity, 
                 : Optional.empty();
     }
 
-    private T jpaEntity(final Object create) {
+    protected T jpaEntity(final Object create) {
         final T jpaEntity = jpaEntityCreator.get();
         ObjectCopyUtil.copy(create, jpaEntity, false, this::attach);
         return jpaEntity;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetFilterQueryManagement.java
@@ -32,6 +32,7 @@ import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.helper.TenantConfigHelper;
 import org.eclipse.hawkbit.repository.jpa.JpaManagementHelper;
+import org.eclipse.hawkbit.repository.jpa.configuration.Constants;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetFilterQuery;
 import org.eclipse.hawkbit.repository.jpa.repository.TargetFilterQueryRepository;
@@ -44,14 +45,18 @@ import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.repository.qfields.TargetFields;
 import org.eclipse.hawkbit.repository.qfields.TargetFilterQueryFields;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 import org.springframework.validation.annotation.Validated;
+
+import static org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey.AUTO_ASSIGNMENT_APPROVAL_ENABLED;
 
 /**
  * JPA implementation of {@link TargetFilterQueryManagement}.
@@ -85,9 +90,19 @@ class JpaTargetFilterQueryManagement
     }
 
     @Override
+    @Transactional
     public JpaTargetFilterQuery create(final Create create) {
         validate(create);
         return super.create(create);
+    }
+
+    @Override
+    protected JpaTargetFilterQuery jpaEntity(final Object create) {
+        final JpaTargetFilterQuery jpaEntity = super.jpaEntity(create);
+        if (jpaEntity.getAutoAssignDistributionSet() != null) {
+            jpaEntity.setAutoAssignStatus(resolveInitialAutoAssignStatus());
+        }
+        return jpaEntity;
     }
 
     @Override
@@ -132,9 +147,9 @@ class JpaTargetFilterQueryManagement
     }
 
     @Override
-    public Slice<TargetFilterQuery> findWithAutoAssignDS(final Pageable pageable) {
+    public Slice<TargetFilterQuery> findWithActiveAutoAssignDS(final Pageable pageable) {
         return JpaManagementHelper.findAllWithoutCountBySpec(
-                jpaRepository, List.of(TargetFilterQuerySpecification.withAutoAssignDS()), pageable);
+                jpaRepository, List.of(TargetFilterQuerySpecification.withActiveAutoAssignDS()), pageable);
     }
 
     @Override
@@ -145,6 +160,10 @@ class JpaTargetFilterQueryManagement
             targetFilterQuery.setAccessControlContext(null);
             targetFilterQuery.setAutoAssignDistributionSet(null);
             targetFilterQuery.setAutoAssignActionType(null);
+            targetFilterQuery.setStartAt(null);
+            targetFilterQuery.setAutoAssignStatus(null);
+            targetFilterQuery.setApprovalDecidedBy(null);
+            targetFilterQuery.setApprovalRemark(null);
             targetFilterQuery.setAutoAssignWeight(0);
             targetFilterQuery.setAutoAssignInitiatedBy(null);
             targetFilterQuery.setConfirmationRequired(false);
@@ -160,6 +179,10 @@ class JpaTargetFilterQueryManagement
             AccessContext.securityContext().ifPresent(targetFilterQuery::setAccessControlContext);
             targetFilterQuery.setAutoAssignInitiatedBy(Optional.ofNullable(AccessContext.actor()).orElse(targetFilterQuery.getCreatedBy()));
             targetFilterQuery.setAutoAssignActionType(sanitizeAutoAssignActionType(update.actionType()));
+            targetFilterQuery.setStartAt(update.startAt());
+            targetFilterQuery.setAutoAssignStatus(resolveInitialAutoAssignStatus());
+            targetFilterQuery.setApprovalDecidedBy(null);
+            targetFilterQuery.setApprovalRemark(null);
             targetFilterQuery.setAutoAssignWeight(update.weight() == null ? repositoryProperties.getActionWeightIfAbsent() : update.weight());
             final boolean confirmationRequired = update.confirmationRequired() == null
                     ? TenantConfigHelper.isUserConfirmationFlowEnabled()
@@ -174,6 +197,21 @@ class JpaTargetFilterQueryManagement
     public void cancelAutoAssignmentForDistributionSet(final long distributionSetId) {
         jpaRepository.unsetAutoAssignDistributionSetAndActionTypeAndAccessContext(distributionSetId);
         log.debug("Auto assignments for distribution sets {} deactivated", distributionSetId);
+    }
+
+    @Override
+    @Transactional
+    @Retryable(includes = ConcurrencyFailureException.class, maxRetriesString = Constants.RETRY_MAX, delayString = Constants.RETRY_DELAY)
+    public TargetFilterQuery start(final long targetFilterQueryId) {
+        final JpaTargetFilterQuery targetFilterQuery = jpaRepository.getById(targetFilterQueryId);
+        targetFilterQuery.setAutoAssignStatus(TargetFilterQuery.AutoAssignStatus.RUNNING);
+        return jpaRepository.save(targetFilterQuery);
+    }
+
+    private TargetFilterQuery.AutoAssignStatus resolveInitialAutoAssignStatus() {
+        return TenantConfigHelper.getAsSystem(AUTO_ASSIGNMENT_APPROVAL_ENABLED, Boolean.class)
+                ? TargetFilterQuery.AutoAssignStatus.WAITING_FOR_APPROVAL
+                : TargetFilterQuery.AutoAssignStatus.READY;
     }
 
     private static ActionType sanitizeAutoAssignActionType(final ActionType actionType) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetFilterQuery.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaTargetFilterQuery.java
@@ -9,10 +9,12 @@
  */
 package org.eclipse.hawkbit.repository.jpa.model;
 
+import java.util.EnumMap;
 import java.util.Optional;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
+import jakarta.persistence.Converter;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -29,6 +31,7 @@ import org.eclipse.hawkbit.repository.event.EventPublisherHolder;
 import org.eclipse.hawkbit.repository.event.remote.TargetFilterQueryDeletedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryCreatedEvent;
 import org.eclipse.hawkbit.repository.event.remote.entity.TargetFilterQueryUpdatedEvent;
+import org.eclipse.hawkbit.repository.jpa.utils.MapAttributeConverter;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.NamedEntity;
@@ -64,6 +67,17 @@ public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity imple
     @Convert(converter = JpaAction.ActionTypeConverter.class)
     private ActionType autoAssignActionType;
 
+    @Column(name = "start_at")
+    private Long startAt;
+
+    @Column(name = "approval_decided_by")
+    @Size(min = 1, max = TargetFilterQuery.APPROVED_BY_MAX_SIZE)
+    private String approvalDecidedBy;
+
+    @Column(name = "approval_remark")
+    @Size(max = TargetFilterQuery.APPROVAL_REMARK_MAX_SIZE)
+    private String approvalRemark;
+
     @Column(name = "auto_assign_weight")
     private Integer autoAssignWeight;
 
@@ -77,6 +91,10 @@ public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity imple
     @Lob
     @Size(max = TargetFilterQuery.ACCESS_CONTROL_CONTEXT_MAX_SIZE)
     private String accessControlContext;
+
+    @Column(name = "auto_assign_status")
+    @Convert(converter = AutoAssignStatusConverter.class)
+    private AutoAssignStatus autoAssignStatus;
 
     public JpaTargetFilterQuery(final String name, final String query, final DistributionSet autoAssignDistributionSet,
             final ActionType autoAssignActionType, final Integer autoAssignWeight, final boolean confirmationRequired) {
@@ -119,5 +137,18 @@ public class JpaTargetFilterQuery extends AbstractJpaTenantAwareBaseEntity imple
     public void fireDeleteEvent() {
         EventPublisherHolder.getInstance().getEventPublisher()
                 .publishEvent(new TargetFilterQueryDeletedEvent(getTenant(), getId(), getClass()));
+    }
+
+    @Converter
+    public static class AutoAssignStatusConverter extends MapAttributeConverter<AutoAssignStatus, Integer> {
+        public AutoAssignStatusConverter() {
+            super(new EnumMap<>(AutoAssignStatus.class) {{
+                put(AutoAssignStatus.WAITING_FOR_APPROVAL, 0);
+                put(AutoAssignStatus.APPROVAL_DENIED, 1);
+                put(AutoAssignStatus.READY, 2);
+                put(AutoAssignStatus.PAUSED, 3);
+                put(AutoAssignStatus.RUNNING, 4);
+            }}, null);
+        }
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/TargetFilterQueryRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/repository/TargetFilterQueryRepository.java
@@ -44,7 +44,7 @@ public interface TargetFilterQueryRepository extends BaseEntityRepository<JpaTar
      */
     @Modifying
     @Transactional
-    @Query("UPDATE JpaTargetFilterQuery d SET d.autoAssignDistributionSet = NULL, d.autoAssignActionType = NULL, d.accessControlContext = NULL WHERE d.autoAssignDistributionSet.id IN :ids")
+    @Query("UPDATE JpaTargetFilterQuery d SET d.autoAssignDistributionSet = NULL, d.autoAssignActionType = NULL, d.accessControlContext = NULL, d.autoAssignStatus = NULL, d.startAt = NULL, d.approvalDecidedBy = NULL, d.approvalRemark = NULL WHERE d.autoAssignDistributionSet.id IN :ids")
     void unsetAutoAssignDistributionSetAndActionTypeAndAccessContext(@Param("ids") Long... dsIds);
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaAutoAssignHandler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/scheduler/JpaAutoAssignHandler.java
@@ -208,11 +208,18 @@ public class JpaAutoAssignHandler implements AutoAssignHandler {
         Slice<TargetFilterQuery> filterQueries;
         Pageable query = PageRequest.of(0, PAGE_SIZE);
         do {
-            filterQueries = targetFilterQueryManagement.findWithAutoAssignDS(query);
+            filterQueries = targetFilterQueryManagement.findWithActiveAutoAssignDS(query);
 
             try {
                 filterQueries.forEach(filterQuery -> {
                     try {
+                        if (filterQuery.getAutoAssignStatus() == TargetFilterQuery.AutoAssignStatus.READY) {
+                            final Long startAt = filterQuery.getStartAt();
+                            if (startAt != null && startAt > System.currentTimeMillis()) {
+                                return;
+                            }
+                            targetFilterQueryManagement.start(filterQuery.getId());
+                        }
                         filterQuery.getAccessControlContext().ifPresentOrElse(
                                 // has stored context - executes it with it
                                 context -> withSecurityContext(context, () -> consumer.accept(filterQuery)),

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetFilterQuerySpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetFilterQuerySpecification.java
@@ -41,8 +41,10 @@ public final class TargetFilterQuerySpecification {
      *
      * @return the {@link JpaTargetFilterQuery} {@link Specification}
      */
-    public static Specification<JpaTargetFilterQuery> withAutoAssignDS() {
-        return (targetFilterQueryRoot, query, cb) -> cb
-                .isNotNull(targetFilterQueryRoot.get(JpaTargetFilterQuery_.autoAssignDistributionSet));
+    public static Specification<JpaTargetFilterQuery> withActiveAutoAssignDS() {
+        return (targetFilterQueryRoot, query, cb) -> cb.and(
+                cb.isNotNull(targetFilterQueryRoot.get(JpaTargetFilterQuery_.autoAssignDistributionSet)),
+                cb.or(cb.equal(targetFilterQueryRoot.get(JpaTargetFilterQuery_.autoAssignStatus), TargetFilterQuery.AutoAssignStatus.RUNNING),
+                        cb.equal(targetFilterQueryRoot.get(JpaTargetFilterQuery_.autoAssignStatus), TargetFilterQuery.AutoAssignStatus.READY)));
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetFilterQueryManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetFilterQueryManagementTest.java
@@ -527,7 +527,7 @@ class TargetFilterQueryManagementTest extends AbstractRepositoryManagementTest<T
 
     private void verifyFindForAllWithAutoAssignDs(final TargetFilterQuery... expectedFilterQueries) {
         final Slice<TargetFilterQuery> tfqList = targetFilterQueryManagement
-                .findWithAutoAssignDS(PageRequest.of(0, 500));
+                .findWithActiveAutoAssignDS(PageRequest.of(0, 500));
 
         assertThat(tfqList.getNumberOfElements()).isEqualTo(expectedFilterQueries.length);
         verifyExpectedFilterQueriesInList(tfqList, expectedFilterQueries);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/scheduler/AutoAssignHandlerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/scheduler/AutoAssignHandlerTest.java
@@ -77,7 +77,7 @@ class AutoAssignHandlerTest {
         when(lock.tryLock()).thenReturn(false);
         when(lockRegistry.obtain(any())).thenReturn(lock);
         final TargetFilterQuery matching = mock(TargetFilterQuery.class);
-        when(targetFilterQueryManagement.findWithAutoAssignDS(any())).thenReturn(new SliceImpl<>(Arrays.asList(matching)));
+        when(targetFilterQueryManagement.findWithActiveAutoAssignDS(any())).thenReturn(new SliceImpl<>(Arrays.asList(matching)));
 
         assertThatNoException().isThrownBy(autoAssignHandler::handleAll);
     }
@@ -91,7 +91,7 @@ class AutoAssignHandlerTest {
         final long ds = getRandomLong();
         final TargetFilterQuery matching = mockFilterQuery(ds);
         final TargetFilterQuery notMatching = mockFilterQuery(ds);
-        when(targetFilterQueryManagement.findWithAutoAssignDS(any())).thenReturn(new SliceImpl<>(Arrays.asList(notMatching, matching)));
+        when(targetFilterQueryManagement.findWithActiveAutoAssignDS(any())).thenReturn(new SliceImpl<>(Arrays.asList(notMatching, matching)));
         when(targetManagement.isTargetMatchingQueryAndDSNotAssignedAndCompatibleAndUpdatable(target, ds, matching.getQuery())).thenReturn(true);
         when(targetManagement.isTargetMatchingQueryAndDSNotAssignedAndCompatibleAndUpdatable(target, ds, notMatching.getQuery()))
                 .thenReturn(false);


### PR DESCRIPTION
## What
Added low-level support for auto assignment approval, not yet functional.
Includes a new status system for auto assignments, approval user and remark and a startAt timestamp

## Changes
- New tenant config property `auto.assignment.approval.enabled`, false by default
- New `AutoAssignStatus` enum in `TargetFilterQuery` with the following states:
    - `WAITING_FOR_APPROVAL`
    - `APPROVAL_DENIED`
    - `READY`
    - `PAUSED`
    - `RUNNING`
- `TargetFilterQuery` now has additional fields `autoAssignStatus`, `startAt`, `approvalDecidedBy`, `approvalRemark`
- Added flyway migration for the new fields
- Auto Assigner Scheduler now processes only `READY` and `RUNNING` auto assignments. If the status is `READY` and the `startAt` time is in the past, it's updated to `RUNNING` and the auto assignment is processed
- On creation/update, depending on the tenant config property, the status is set to either `WAITING_FOR_APPROVAL` if `auto.assignment.approval.enabled` is true or `READY` otherwise
- Old entries are updated to have the status `RUNNING`

## Notes
- For the tests to pass, the `startAt` property is set to the current time, which at a later date should be changed to `null` so that if the start time is not set, the auto assignment should never auto-start

Signed-off-by: Marinov Kaloyan <kaloyan.marinov@bosch.com>