### PR TITLE
Allow vaadin 25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,8 +40,6 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa"
         versions: [ ">= 5.0.0" ]
-      - dependency-name: "com.vaadin:*"
-        versions: [ ">= 25.0.0" ]
   - package-ecosystem: "docker"
     directory: "/docker"
     target-branch: "1.0"


### PR DESCRIPTION
Because 1.0 now supports Vaadin 25.x, removed the ignore for Vaadin 25.x versions in dependabot
    
Signed-off-by: Marinov Kaloyan <kaloyan.marinov@bosch.com>