### PR TITLE
Allow RUNNING -> WAIT_FOR_CONFIRMATION via DDI 'denied' feedback

### DIFF
--- a/hawkbit-ddi/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfirmationBaseTest.java
+++ b/hawkbit-ddi/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfirmationBaseTest.java
@@ -468,6 +468,57 @@ class DdiConfirmationBaseTest extends AbstractDDiApiIntegrationTest {
     }
 
     /**
+     * Controller sends a 'denied' feedback for a canceled action which must be rejected in order to keep the pending
+     * cancellation visible to the device.
+     */
+    @Test
+    void revokeConfirmationIsRejectedForCancelingAction() throws Exception {
+        enableConfirmationFlow();
+
+        final DistributionSet ds = testdataFactory.createDistributionSet("");
+        Target savedTarget = testdataFactory.createTarget("992");
+        savedTarget = getFirstAssignedTarget(assignDistributionSet(ds.getId(), savedTarget.getControllerId()));
+        final String controllerId = savedTarget.getControllerId();
+        final Action savedAction = deploymentManagement.findActiveActionsByTarget(controllerId, PAGE).getContent().get(0);
+
+        // confirm -> action RUNNING, afterwards soft cancel it -> CANCELING
+        sendConfirmationFeedback(
+                savedTarget, savedAction, DdiConfirmationFeedback.Confirmation.CONFIRMED, 10, "Action confirmed message.")
+                .andExpect(status().isOk());
+        assertThat(deploymentManagement.cancelAction(savedAction.getId()).getStatus()).isEqualTo(Action.Status.CANCELING);
+
+        sendConfirmationFeedback(
+                savedTarget, savedAction, DdiConfirmationFeedback.Confirmation.DENIED, 20, "Consent revoked message.")
+                .andExpect(status().isNotFound());
+
+        assertThat(deploymentManagement.findAction(savedAction.getId()).orElseThrow().getStatus())
+                .isEqualTo(Action.Status.CANCELING);
+    }
+
+    /**
+     * Controller sends a 'denied' feedback for a running action while the confirmation flow is disabled, which must be
+     * rejected since the action never has been confirmation-driven.
+     */
+    @Test
+    void revokeConfirmationIsRejectedIfConfirmationFlowIsDisabled() throws Exception {
+        final DistributionSet ds = testdataFactory.createDistributionSet("");
+        Target savedTarget = testdataFactory.createTarget("993");
+        savedTarget = getFirstAssignedTarget(assignDistributionSet(ds.getId(), savedTarget.getControllerId()));
+        final String controllerId = savedTarget.getControllerId();
+        final Action savedAction = deploymentManagement.findActiveActionsByTarget(controllerId, PAGE).getContent().get(0);
+        assertThat(savedAction.getStatus()).isEqualTo(Action.Status.RUNNING);
+
+        sendConfirmationFeedback(
+                savedTarget, savedAction, DdiConfirmationFeedback.Confirmation.DENIED, 20, "Consent revoked message.")
+                .andExpect(status().isNotFound());
+
+        // action remains running and the deploymentBase is still exposed
+        assertThat(deploymentManagement.findAction(savedAction.getId()).orElseThrow().getStatus())
+                .isEqualTo(Action.Status.RUNNING);
+        verifyActionInDeploymentBaseState(controllerId, savedAction.getId());
+    }
+
+    /**
      * Test to verify that only a specific count of messages are returned based on the input actionHistory for getControllerDeploymentActionFeedback endpoint.
      */
     @Test

--- a/hawkbit-ddi/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfirmationBaseTest.java
+++ b/hawkbit-ddi/hawkbit-ddi-resource/src/test/java/org/eclipse/hawkbit/ddi/rest/resource/DdiConfirmationBaseTest.java
@@ -430,6 +430,44 @@ class DdiConfirmationBaseTest extends AbstractDDiApiIntegrationTest {
     }
 
     /**
+     * Controller revokes a previously granted confirmation via 'denied' feedback, reverting the RUNNING action back to
+     * WAIT_FOR_CONFIRMATION so that the confirmationBase is offered again and the action can be re-confirmed.
+     */
+    @Test
+    void revokeConfirmationRevertsRunningActionToConfirmationBase() throws Exception {
+        enableConfirmationFlow();
+
+        final DistributionSet ds = testdataFactory.createDistributionSet("");
+        Target savedTarget = testdataFactory.createTarget("991");
+        savedTarget = getFirstAssignedTarget(assignDistributionSet(ds.getId(), savedTarget.getControllerId()));
+        final String controllerId = savedTarget.getControllerId();
+        final Action savedAction = deploymentManagement.findActiveActionsByTarget(controllerId, PAGE).getContent().get(0);
+
+        // confirm -> action RUNNING, deploymentBase exposed
+        sendConfirmationFeedback(
+                savedTarget, savedAction, DdiConfirmationFeedback.Confirmation.CONFIRMED, 10, "Action confirmed message.")
+                .andExpect(status().isOk());
+        verifyActionInDeploymentBaseState(controllerId, savedAction.getId());
+
+        // deny -> previously granted confirmation revoked, action reverted to WAIT_FOR_CONFIRMATION
+        sendConfirmationFeedback(
+                savedTarget, savedAction, DdiConfirmationFeedback.Confirmation.DENIED, 20, "Consent revoked message.")
+                .andExpect(status().isOk());
+        // subsequent poll offers confirmationBase again and no longer the deploymentBase
+        verifyActionInConfirmationBaseState(controllerId, savedAction.getId());
+        mvc.perform(get(DEPLOYMENT_BASE, AccessContext.tenant(), controllerId, savedAction.getId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultPrinter.print())
+                .andExpect(status().isNotFound());
+
+        // re-confirm -> action returns to RUNNING and deploymentBase is exposed again
+        sendConfirmationFeedback(
+                savedTarget, savedAction, DdiConfirmationFeedback.Confirmation.CONFIRMED, 10, "Action re-confirmed message.")
+                .andExpect(status().isOk());
+        verifyActionInDeploymentBaseState(controllerId, savedAction.getId());
+    }
+
+    /**
      * Test to verify that only a specific count of messages are returned based on the input actionHistory for getControllerDeploymentActionFeedback endpoint.
      */
     @Test

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ConfirmationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ConfirmationManagement.java
@@ -61,6 +61,10 @@ public interface ConfirmationManagement extends PermissionSupport {
      * action that is either still in {@link Action.Status#WAIT_FOR_CONFIRMATION} (stays there) or already in
      * {@link Action.Status#RUNNING} because a previously granted confirmation (auto- or manually given) is revoked, which reverts the
      * action back to {@link Action.Status#WAIT_FOR_CONFIRMATION}.
+     * <p/>
+     * Revoking a previously granted confirmation is rejected in case the action is not confirmation-driven anymore, i.e. if the action
+     * is in {@link Action.Status#CANCELING} / {@link Action.Status#CANCELED} state (the target is served a cancel action instead of a
+     * confirmation base) or if the user confirmation flow is disabled for the tenant.
      *
      * @param actionId mandatory to know which action to deny
      * @param code optional value to specify a code for the created action status

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ConfirmationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ConfirmationManagement.java
@@ -57,7 +57,10 @@ public interface ConfirmationManagement extends PermissionSupport {
     Action confirmAction(long actionId, Integer code, Collection<String> messages);
 
     /**
-     * Deny a given action and leave it in {@link Action.Status#WAIT_FOR_CONFIRMATION} state.
+     * Deny a given action and set it to {@link Action.Status#WAIT_FOR_CONFIRMATION} state. A denied feedback is accepted for an active
+     * action that is either still in {@link Action.Status#WAIT_FOR_CONFIRMATION} (stays there) or already in
+     * {@link Action.Status#RUNNING} because a previously granted confirmation (auto- or manually given) is revoked, which reverts the
+     * action back to {@link Action.Status#WAIT_FOR_CONFIRMATION}.
      *
      * @param actionId mandatory to know which action to deny
      * @param code optional value to specify a code for the created action status

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaConfirmationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaConfirmationManagement.java
@@ -122,12 +122,19 @@ public class JpaConfirmationManagement extends JpaActionManagement implements Co
     public Action denyAction(final long actionId, final Integer code, final Collection<String> deviceMessages) {
         log.trace("Action with id {} deny request is triggered.", actionId);
         final Action action = actionRepository.getById(actionId);
-        assertActionCanAcceptFeedback(action);
+        assertActionCanBeDenied(action);
         final List<String> messages = new ArrayList<>();
         if (deviceMessages != null) {
             messages.addAll(deviceMessages);
         }
-        messages.add(SERVER_MESSAGE_PREFIX + "Target rejected action. Action will stay in confirmation pending state.");
+        if (action.getStatus() == Status.WAIT_FOR_CONFIRMATION) {
+            messages.add(SERVER_MESSAGE_PREFIX + "Target rejected action. Action will stay in confirmation pending state.");
+        } else {
+            // the target revokes a previously granted confirmation (auto- or manually confirmed) for an action that has not
+            // been installed yet - revert it back to WAIT_FOR_CONFIRMATION
+            messages.add(SERVER_MESSAGE_PREFIX
+                    + "Target revoked previously granted confirmation. Action returned to confirmation-pending state.");
+        }
         return addActionStatus(createConfirmationActionStatus(action.getId(), code, messages).status(Status.WAIT_FOR_CONFIRMATION).build());
     }
 
@@ -155,8 +162,13 @@ public class JpaConfirmationManagement extends JpaActionManagement implements Co
 
     @Override
     protected void onActionStatusUpdate(final JpaActionStatus newActionStatus, final JpaAction action) {
-        if (newActionStatus.getStatus() == Status.RUNNING && action.isActive()) {
-            action.setStatus(Status.RUNNING);
+        if (action.isActive()) {
+            if (newActionStatus.getStatus() == Status.RUNNING) {
+                action.setStatus(Status.RUNNING);
+            } else if (newActionStatus.getStatus() == Status.WAIT_FOR_CONFIRMATION) {
+                // a denied feedback reverts an already confirmed (RUNNING) action back to the confirmation-pending state
+                action.setStatus(Status.WAIT_FOR_CONFIRMATION);
+            }
         }
     }
 
@@ -173,6 +185,20 @@ public class JpaConfirmationManagement extends JpaActionManagement implements Co
             log.warn(msg);
             throw new InvalidConfirmationFeedbackException(
                     InvalidConfirmationFeedbackException.Reason.NOT_AWAITING_CONFIRMATION, msg);
+        }
+    }
+
+    private static void assertActionCanBeDenied(final Action action) {
+        // a denied feedback is accepted while awaiting confirmation (stays in confirmation-pending state) or for an
+        // already confirmed but not yet installed action, in which case the previously granted confirmation is revoked
+        // and the action reverts to the confirmation-pending state. As the device is the authority on whether it may
+        // still revoke consent, there is no maintenance-window or progress gating - only closed actions are rejected.
+        if (!action.isActive()) {
+            final String msg = String.format(
+                    "Denying action %s is not possible since the action is not active anymore.", action.getId());
+            log.warn(msg);
+            throw new InvalidConfirmationFeedbackException(InvalidConfirmationFeedbackException.Reason.ACTION_CLOSED,
+                    msg);
         }
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaConfirmationManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaConfirmationManagement.java
@@ -25,6 +25,7 @@ import org.eclipse.hawkbit.repository.QuotaManagement;
 import org.eclipse.hawkbit.repository.RepositoryProperties;
 import org.eclipse.hawkbit.repository.exception.AutoConfirmationAlreadyActiveException;
 import org.eclipse.hawkbit.repository.exception.InvalidConfirmationFeedbackException;
+import org.eclipse.hawkbit.repository.helper.TenantConfigHelper;
 import org.eclipse.hawkbit.repository.jpa.JpaManagementHelper;
 import org.eclipse.hawkbit.repository.jpa.configuration.Constants;
 import org.eclipse.hawkbit.repository.jpa.model.JpaAction;
@@ -165,8 +166,9 @@ public class JpaConfirmationManagement extends JpaActionManagement implements Co
         if (action.isActive()) {
             if (newActionStatus.getStatus() == Status.RUNNING) {
                 action.setStatus(Status.RUNNING);
-            } else if (newActionStatus.getStatus() == Status.WAIT_FOR_CONFIRMATION) {
-                // a denied feedback reverts an already confirmed (RUNNING) action back to the confirmation-pending state
+            } else if (newActionStatus.getStatus() == Status.WAIT_FOR_CONFIRMATION && !action.isCancelingOrCanceled()) {
+                // a denied feedback reverts an already confirmed (RUNNING) action back to the confirmation-pending
+                // state. A pending cancellation must never be overruled by that.
                 action.setStatus(Status.WAIT_FOR_CONFIRMATION);
             }
         }
@@ -192,13 +194,42 @@ public class JpaConfirmationManagement extends JpaActionManagement implements Co
         // a denied feedback is accepted while awaiting confirmation (stays in confirmation-pending state) or for an
         // already confirmed but not yet installed action, in which case the previously granted confirmation is revoked
         // and the action reverts to the confirmation-pending state. As the device is the authority on whether it may
-        // still revoke consent, there is no maintenance-window or progress gating - only closed actions are rejected.
+        // still revoke consent, there is no maintenance-window or progress gating.
         if (!action.isActive()) {
             final String msg = String.format(
                     "Denying action %s is not possible since the action is not active anymore.", action.getId());
             log.warn(msg);
             throw new InvalidConfirmationFeedbackException(InvalidConfirmationFeedbackException.Reason.ACTION_CLOSED,
                     msg);
+        }
+
+        if (action.isWaitingConfirmation()) {
+            // the regular case - the action awaits confirmation and just stays there
+            return;
+        }
+
+        // from here on the feedback would revoke an already granted confirmation, which is only valid as long as the
+        // action is still a confirmation-driven one
+        if (action.isCancelingOrCanceled()) {
+            // the action is (soft) canceled, i.e. the target is served a cancel action on poll and not a confirmation
+            // base. Reverting it to WAIT_FOR_CONFIRMATION would hide the pending cancellation from the device.
+            final String msg = String.format(
+                    "Denying action %s is not possible since the action is in %s state and hence not confirmation-pending anymore.",
+                    action.getId(), action.getStatus());
+            log.warn(msg);
+            throw new InvalidConfirmationFeedbackException(
+                    InvalidConfirmationFeedbackException.Reason.NOT_AWAITING_CONFIRMATION, msg);
+        }
+
+        if (!TenantConfigHelper.isUserConfirmationFlowEnabled()) {
+            // without an active confirmation flow an action shall never end up in WAIT_FOR_CONFIRMATION. Actions that
+            // have been created while the flow was still enabled remain deniable since they are in WAIT_FOR_CONFIRMATION
+            // (handled above).
+            final String msg = String.format(
+                    "Denying action %s is not possible since the confirmation flow is not enabled.", action.getId());
+            log.warn(msg);
+            throw new InvalidConfirmationFeedbackException(
+                    InvalidConfirmationFeedbackException.Reason.NOT_AWAITING_CONFIRMATION, msg);
         }
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ConfirmationManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ConfirmationManagementTest.java
@@ -256,6 +256,76 @@ class ConfirmationManagementTest extends AbstractJpaIntegrationTest {
     }
 
     /**
+     * Verify denying a canceling action is rejected and keeps the action in canceling state
+     */
+    @Test
+    void deniedActionNotPossibleForCancelingAction() {
+        enableConfirmationFlow();
+
+        final String controllerId = testdataFactory.createTarget().getControllerId();
+        final Long dsId = testdataFactory.createDistributionSet().getId();
+
+        final List<Action> actions = assignDistributionSet(dsId, controllerId).getAssignedEntity();
+        assertThat(actions).hasSize(1);
+        final Long actionId = actions.get(0).getId();
+
+        // confirm -> RUNNING and cancel it afterwards (soft cancel) -> CANCELING
+        assertThat(confirmationManagement.confirmAction(actionId, null, null).getStatus()).isEqualTo(Status.RUNNING);
+        assertThat(deploymentManagement.cancelAction(actionId).getStatus()).isEqualTo(Status.CANCELING);
+
+        // the target gets a cancel action on poll - denying must not push it back to WAIT_FOR_CONFIRMATION
+        assertThatThrownBy(() -> confirmationManagement.denyAction(actionId, null, null))
+                .isInstanceOf(InvalidConfirmationFeedbackException.class)
+                .matches(e -> ((InvalidConfirmationFeedbackException) e)
+                        .getReason() == InvalidConfirmationFeedbackException.Reason.NOT_AWAITING_CONFIRMATION);
+
+        assertThat(deploymentManagement.findAction(actionId).orElseThrow().getStatus()).isEqualTo(Status.CANCELING);
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).isEmpty();
+    }
+
+    /**
+     * Verify denying a running action is rejected in case the confirmation flow is disabled
+     */
+    @Test
+    void deniedActionNotPossibleWithDisabledConfirmationFlow() {
+        final String controllerId = testdataFactory.createTarget().getControllerId();
+        final Long dsId = testdataFactory.createDistributionSet().getId();
+
+        // confirmation flow disabled -> action is directly in RUNNING state
+        final List<Action> actions = assignDistributionSet(dsId, controllerId).getAssignedEntity();
+        assertThat(actions).hasSize(1).allMatch(action -> action.getStatus() == Status.RUNNING);
+        final Long actionId = actions.get(0).getId();
+
+        assertThatThrownBy(() -> confirmationManagement.denyAction(actionId, null, null))
+                .isInstanceOf(InvalidConfirmationFeedbackException.class)
+                .matches(e -> ((InvalidConfirmationFeedbackException) e)
+                        .getReason() == InvalidConfirmationFeedbackException.Reason.NOT_AWAITING_CONFIRMATION);
+
+        assertThat(deploymentManagement.findAction(actionId).orElseThrow().getStatus()).isEqualTo(Status.RUNNING);
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).isEmpty();
+    }
+
+    /**
+     * Verify an action waiting for confirmation can still be denied after the confirmation flow got disabled
+     */
+    @Test
+    void deniedActionStillPossibleForWfcActionAfterDisablingConfirmationFlow() {
+        enableConfirmationFlow();
+
+        final String controllerId = testdataFactory.createTarget().getControllerId();
+        final Long dsId = testdataFactory.createDistributionSet().getId();
+
+        final List<Action> actions = assignDistributionSet(dsId, controllerId).getAssignedEntity();
+        assertThat(actions).hasSize(1).allMatch(action -> action.getStatus() == Status.WAIT_FOR_CONFIRMATION);
+        final Long actionId = actions.get(0).getId();
+
+        disableConfirmationFlow();
+
+        assertThat(confirmationManagement.denyAction(actionId, null, null).getStatus())
+                .isEqualTo(Status.WAIT_FOR_CONFIRMATION);
+    }
+
+    /**
      * Verify action in WFC state will be transferred in RUNNING state in case auto-confirmation is activated.
      */
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ConfirmationManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/ConfirmationManagementTest.java
@@ -159,6 +159,103 @@ class ConfirmationManagementTest extends AbstractJpaIntegrationTest {
     }
 
     /**
+     * Verify denying a manually confirmed (RUNNING) action reverts it back to WFC state
+     */
+    @Test
+    void deniedActionAfterManualConfirmRevertsToWfcState() {
+        enableConfirmationFlow();
+
+        final String controllerId = testdataFactory.createTarget().getControllerId();
+        final Long dsId = testdataFactory.createDistributionSet().getId();
+
+        final List<Action> actions = assignDistributionSet(dsId, controllerId).getAssignedEntity();
+        assertThat(actions).hasSize(1).allMatch(action -> action.getStatus() == Status.WAIT_FOR_CONFIRMATION);
+        final Long actionId = actions.get(0).getId();
+
+        // manual consent -> RUNNING
+        assertThat(confirmationManagement.confirmAction(actionId, null, null).getStatus()).isEqualTo(Status.RUNNING);
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).isEmpty();
+
+        // revoke consent -> back to WAIT_FOR_CONFIRMATION
+        final Action revokedAction = confirmationManagement.denyAction(actionId, null, null);
+        assertThat(revokedAction.getStatus()).isEqualTo(Status.WAIT_FOR_CONFIRMATION);
+
+        // action is offered for confirmation again
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).hasSize(1)
+                .allMatch(action -> action.getStatus() == Status.WAIT_FOR_CONFIRMATION);
+
+        // audit trail: WFC (initial) -> RUNNING (confirm) -> WAIT_FOR_CONFIRMATION (revoke)
+        assertThat(controllerManagement.findActionStatusByAction(actionId, PAGE)).hasSize(3)
+                .anyMatch(status -> status.getStatus() == Status.RUNNING)
+                .anyMatch(status -> status.getStatus() == Status.WAIT_FOR_CONFIRMATION);
+    }
+
+    /**
+     * Verify denying an auto-confirmed (RUNNING) action reverts it back to WFC state
+     */
+    @Test
+    void deniedActionAfterAutoConfirmRevertsToWfcState() {
+        enableConfirmationFlow();
+
+        final String controllerId = testdataFactory.createTarget().getControllerId();
+        final Long dsId = testdataFactory.createDistributionSet().getId();
+
+        // auto-confirmation -> assigned action goes straight to RUNNING
+        confirmationManagement.activateAutoConfirmation(controllerId, null, null);
+
+        final List<Action> actions = assignDistributionSet(dsId, controllerId).getAssignedEntity();
+        assertThat(actions).hasSize(1).allMatch(action -> action.getStatus() == Status.RUNNING);
+        final Long actionId = actions.get(0).getId();
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).isEmpty();
+
+        // revoke consent -> back to WAIT_FOR_CONFIRMATION
+        final Action revokedAction = confirmationManagement.denyAction(actionId, null, null);
+        assertThat(revokedAction.getStatus()).isEqualTo(Status.WAIT_FOR_CONFIRMATION);
+
+        // action is offered for confirmation again
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).hasSize(1)
+                .allMatch(action -> action.getStatus() == Status.WAIT_FOR_CONFIRMATION);
+    }
+
+    /**
+     * Verify a revoked (reverted to WFC) action can be confirmed again and returns to RUNNING
+     */
+    @Test
+    void revokedActionCanBeConfirmedAgain() {
+        enableConfirmationFlow();
+
+        final String controllerId = testdataFactory.createTarget().getControllerId();
+        final Long dsId = testdataFactory.createDistributionSet().getId();
+
+        final List<Action> actions = assignDistributionSet(dsId, controllerId).getAssignedEntity();
+        assertThat(actions).hasSize(1);
+        final Long actionId = actions.get(0).getId();
+
+        // confirm -> RUNNING
+        assertThat(confirmationManagement.confirmAction(actionId, null, null).getStatus()).isEqualTo(Status.RUNNING);
+        // revoke -> WAIT_FOR_CONFIRMATION
+        assertThat(confirmationManagement.denyAction(actionId, null, null).getStatus())
+                .isEqualTo(Status.WAIT_FOR_CONFIRMATION);
+        // re-confirm -> RUNNING again
+        assertThat(confirmationManagement.confirmAction(actionId, null, null).getStatus()).isEqualTo(Status.RUNNING);
+
+        assertThat(confirmationManagement.findActiveActionsWaitingConfirmation(controllerId)).isEmpty();
+    }
+
+    /**
+     * Verify denying a closed action will lead to a specific failure
+     */
+    @Test
+    void deniedActionCannotBeGivenOnFinishedAction() {
+        enableConfirmationFlow();
+        final Long actionId = prepareFinishedUpdate().getId();
+        assertThatThrownBy(() -> confirmationManagement.denyAction(actionId, null, null))
+                .isInstanceOf(InvalidConfirmationFeedbackException.class)
+                .matches(e -> ((InvalidConfirmationFeedbackException) e)
+                        .getReason() == InvalidConfirmationFeedbackException.Reason.ACTION_CLOSED);
+    }
+
+    /**
      * Verify action in WFC state will be transferred in RUNNING state in case auto-confirmation is activated.
      */
     @Test


### PR DESCRIPTION
Extend the confirmation flow so a device can revoke a previously granted consent (auto- or manually confirmed) for an action that has not been installed yet, by sending 'confirmation: "denied"' to the existing confirmationBase/{actionId}/feedback endpoint.

- Relax denyAction guard so a 'denied' feedback is accepted for any active action, not only while WAIT_FOR_CONFIRMATION. An already-confirmed active action reverts to WAIT_FOR_CONFIRMATION with no maintenance-window or progress gating.
- Record a distinct ActionStatus audit-trail message for the revocation, separate from a first-time deny.
- No new DDI endpoint or management API method is introduced.

Tests cover deny after auto-confirm, deny after manual confirm, subsequent base-resource poll offering confirmationBase again, and re-confirmation returning to RUNNING.

Fixes eclipse-hawkbit/hawkbit#3220