### PR TITLE
Bump github/codeql-action from 4 to 4.37.3 (#3246)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -42,7 +42,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -53,6 +53,6 @@ jobs:
         run: mvn install -DskipTests
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/reusable_workflow_trivy-scan.yaml
+++ b/.github/workflows/reusable_workflow_trivy-scan.yaml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload Docker image scan results to GitHub Security tab hawkbit-ddi-server
         if: ${{ inputs.upload }}
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           ref: ${{ steps.upload-ref.outputs.ref }}
           sha: ${{ steps.get-sha.outputs.sha }}
@@ -138,7 +138,7 @@ jobs:
           category: "Container Images (hawkbit-ddi-server) [${{ inputs.ref }}]"
       - name: Upload Docker image scan results to GitHub Security tab hawkbit-dmf-server
         if: ${{ inputs.upload }}
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           ref: ${{ steps.upload-ref.outputs.ref }}
           sha: ${{ steps.get-sha.outputs.sha }}
@@ -146,7 +146,7 @@ jobs:
           category: "Container Images (hawkbit-dmf-server) [${{ inputs.ref }}]"
       - name: Upload Docker image scan results to GitHub Security tab hawkbit-mgmt-server
         if: ${{ inputs.upload }}
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           ref: ${{ steps.upload-ref.outputs.ref }}
           sha: ${{ steps.get-sha.outputs.sha }}
@@ -154,7 +154,7 @@ jobs:
           category: "Container Images (hawkbit-mgmt-server) [${{ inputs.ref }}]"
       - name: Upload Docker image scan results to GitHub Security tab hawkbit-ui
         if: ${{ inputs.upload }}
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           ref: ${{ steps.upload-ref.outputs.ref }}
           sha: ${{ steps.get-sha.outputs.sha }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload Docker image scan results to GitHub Security tab hawkbit-update-server
         if: ${{ inputs.upload }}
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           ref: ${{ steps.upload-ref.outputs.ref }}
           sha: ${{ steps.get-sha.outputs.sha }}
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload Docker image scan results to GitHub Security tab hawkbit-repository-jpa-init
         if: ${{ inputs.upload }}
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           ref: ${{ steps.upload-ref.outputs.ref }}
           sha: ${{ steps.get-sha.outputs.sha }}


### PR DESCRIPTION
Backport of #3246 to the `1.1` branch.

Bumps [github/codeql-action](https://github.com/github/codeql-action) from 4 to 4.37.3 across `codeql.yaml` and `reusable_workflow_trivy-scan.yaml`.

Cherry-picked from cb401ba56.
