### PR TITLE
Auto assignments now don't get a status reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ spring-shell.log
 
 # AI
 .claude
+CLAUDE.md
 .superpowers
 docs/superpowers
 graphify-out

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetFilterQueryResourceTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.hawkbit.mgmt.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.hawkbit.repository.model.AutoAssignment.AutoAssignStatus.RUNNING;
 import static org.eclipse.hawkbit.rest.util.MockMvcResultPrinter.print;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -295,12 +296,16 @@ public class MgmtTargetFilterQueryResourceTest extends AbstractManagementApiInte
         final String filterQuery = "name==test_03";
         final String body = new JSONObject().put("name", filterName2).toString();
 
-        autoAssignmentManagement.create(AutoAssignmentManagement.Create.builder()
+        final AutoAssignment autoAssignment = autoAssignmentManagement.create(AutoAssignmentManagement.Create.builder()
                 .name(filterName)
                 .targetFilterQuery(filterQuery)
                 .distributionSet(testdataFactory.createDistributionSet()).
                 build());
 
+        //start to make sure that the status remains the same after update
+        autoAssignmentManagement.start(autoAssignment.getId());
+
+        assertThat(autoAssignmentManagement.get(autoAssignment.getId()).getStatus()).isEqualTo(RUNNING);
         assertThat(autoAssignmentManagement.findByName(filterName2)).isNotPresent();
 
         // prepare
@@ -320,6 +325,7 @@ public class MgmtTargetFilterQueryResourceTest extends AbstractManagementApiInte
         assertThat(tfqCheck.getName()).isEqualTo(filterName2);
         assertThat(autoAssignmentManagement.findByName(filterName)).isNotPresent();
         assertThat(autoAssignmentManagement.findByName(filterName2)).isPresent();
+        assertThat(autoAssignmentManagement.findByName(filterName2).get().getStatus()).isEqualTo(RUNNING);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetFilterQueryManagement.java
@@ -79,8 +79,8 @@ class JpaTargetFilterQueryManagement
     @Override
     @Transactional
     public JpaTargetFilterQuery update(final Update update) {
-        updateAutoAssignment(update);
         validate(update);
+        updateAutoAssignment(update);
         return super.update(update);
     }
 
@@ -88,8 +88,8 @@ class JpaTargetFilterQueryManagement
     @Transactional
     public Map<Long, JpaTargetFilterQuery> update(final Collection<Update> updates) {
         updates.forEach(update -> {
-            updateAutoAssignment(update);
             validate(update);
+            updateAutoAssignment(update);
         });
         return super.update(updates);
     }
@@ -117,7 +117,6 @@ class JpaTargetFilterQueryManagement
     @Override
     @Transactional
     public AutoAssignment createLinkedAutoAssignment(final long id, final AutoAssignmentManagement.Create create) {
-
         unlinkAutoAssignment(id);
         findLinkedAutoAssignment(id).ifPresent(autoAssignment -> autoAssignmentManagement.delete(autoAssignment.getId()));
         entityManager.flush();
@@ -162,35 +161,32 @@ class JpaTargetFilterQueryManagement
         });
     }
 
-    private void validate(final Update update) {
-        final JpaTargetFilterQuery targetFilterQuery = jpaRepository.getById(update.getId());
-        Optional.ofNullable(update.getQuery()).ifPresent(query -> {
-            // validate the RSQL query syntax
-            QLSupport.getInstance().validate(query, TargetFields.class, JpaTarget.class);
-            // set the new query
-            targetFilterQuery.setQuery(query);
-        });
-    }
-
-    private void updateAutoAssignment(Update update) {
+    private void updateAutoAssignment(final Update update) {
         findLinkedAutoAssignment(update.getId()).ifPresent(autoAssignment -> {
-            AutoAssignmentManagement.Create create = AutoAssignmentManagement.Create.builder()
-                    .name(update.getName() != null ? update.getName() : autoAssignment.getName())
-                    .description(autoAssignment.getDescription())
-                    .targetFilterQuery(update.getQuery() != null ? update.getQuery() : autoAssignment.getTargetFilterQuery())
-                    .distributionSet(autoAssignment.getDistributionSet())
-                    .actionType(autoAssignment.getActionType())
-                    .confirmationRequired(autoAssignment.isConfirmationRequired())
-                    .weight(autoAssignment.getWeight().orElse(null))
-                    .startAt(autoAssignment.getStartAt())
-                    .build();
-            unlinkAutoAssignment(update.getId());
-            autoAssignmentManagement.delete(autoAssignment.getId());
-            entityManager.flush();
-            autoAssignmentManagement.create(create);
+            if (update.getQuery() != null && !update.getQuery().equals(get(update.getId()).getQuery())) {
+                AutoAssignment assignment = autoAssignment;
+                AutoAssignmentManagement.Create create = AutoAssignmentManagement.Create.builder()
+                        .name(update.getName() != null ? update.getName() : assignment.getName())
+                        .description(assignment.getDescription())
+                        .targetFilterQuery(update.getQuery())
+                        .distributionSet(assignment.getDistributionSet())
+                        .actionType(assignment.getActionType())
+                        .confirmationRequired(assignment.isConfirmationRequired())
+                        .weight(assignment.getWeight().orElse(null))
+                        .startAt(assignment.getStartAt())
+                        .build();
+                unlinkAutoAssignment(update.getId());
+                autoAssignmentManagement.delete(assignment.getId());
+                entityManager.flush();
+                autoAssignmentManagement.create(create);
+            } else if (update.getName() != null && !update.getName().equals(autoAssignment.getName())) {
+                autoAssignmentManagement.update(AutoAssignmentManagement.Update.builder()
+                        .id(autoAssignment.getId())
+                        .name(update.getName())
+                        .build());
+            }
         });
     }
-
 
     /**
      * Clears the in-memory link from the target filter query to its (read-only mapped) auto assignment.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetFilterQueryManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/JpaTargetFilterQueryManagement.java
@@ -173,22 +173,29 @@ class JpaTargetFilterQueryManagement
     }
 
     private void updateAutoAssignment(Update update) {
-        findLinkedAutoAssignment(update.getId()).ifPresent(autoAssignment -> {
+        final Optional<AutoAssignment> autoAssignment = findLinkedAutoAssignment(update.getId());
+        if (update.getQuery() != null && autoAssignment.isPresent()) {
+            AutoAssignment assignment = autoAssignment.get();
             AutoAssignmentManagement.Create create = AutoAssignmentManagement.Create.builder()
-                    .name(update.getName() != null ? update.getName() : autoAssignment.getName())
-                    .description(autoAssignment.getDescription())
-                    .targetFilterQuery(update.getQuery() != null ? update.getQuery() : autoAssignment.getTargetFilterQuery())
-                    .distributionSet(autoAssignment.getDistributionSet())
-                    .actionType(autoAssignment.getActionType())
-                    .confirmationRequired(autoAssignment.isConfirmationRequired())
-                    .weight(autoAssignment.getWeight().orElse(null))
-                    .startAt(autoAssignment.getStartAt())
+                    .name(update.getName() != null ? update.getName() : assignment.getName())
+                    .description(assignment.getDescription())
+                    .targetFilterQuery(update.getQuery())
+                    .distributionSet(assignment.getDistributionSet())
+                    .actionType(assignment.getActionType())
+                    .confirmationRequired(assignment.isConfirmationRequired())
+                    .weight(assignment.getWeight().orElse(null))
+                    .startAt(assignment.getStartAt())
                     .build();
             unlinkAutoAssignment(update.getId());
-            autoAssignmentManagement.delete(autoAssignment.getId());
+            autoAssignmentManagement.delete(assignment.getId());
             entityManager.flush();
             autoAssignmentManagement.create(create);
-        });
+        } else if (update.getName() != null && autoAssignment.isPresent()) {
+            autoAssignmentManagement.update(AutoAssignmentManagement.Update.builder()
+                    .id(autoAssignment.get().getId())
+                    .name(update.getName())
+                    .build());
+        }
     }
 
 


### PR DESCRIPTION
When a target filter query gets only a name update, the auto assignment linked to it now doesn't get reset, but gets just an update. Also an empty update of a target filter query doesn't recreate the auto assignment