### PR TITLE
Hawkbit UI Auto Assignment view

### DIFF
--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtAutoAssignmentMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtAutoAssignmentMapper.java
@@ -48,9 +48,8 @@ public class MgmtAutoAssignmentMapper {
     public static MgmtAutoAssignmentResponseBody toResponseAutoAssignment(final AutoAssignment autoAssignment) {
 
         final MgmtAutoAssignmentResponseBody body = new MgmtAutoAssignmentResponseBody();
+        MgmtRestModelMapper.mapNamedToNamed(body, autoAssignment);
         body.setId(autoAssignment.getId());
-        body.setName(autoAssignment.getName());
-        body.setDescription(autoAssignment.getDescription());
         body.setDistributionSetId(autoAssignment.getDistributionSet().getId());
         body.setTargetFilterQuery(autoAssignment.getTargetFilterQuery());
         body.setStatus(autoAssignment.getStatus().toString().toLowerCase());

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitMgmtClient.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/HawkbitMgmtClient.java
@@ -89,6 +89,10 @@ public class HawkbitMgmtClient {
         return hasRead(() -> tenantManagementRestApi.getTenantConfigurationValue("_#ETE$ER"));
     }
 
+    public boolean hasAutoAssignmentRead() {
+        return hasRead(() -> autoAssignmentRestApi.getAutoAssignment(-1L));
+    }
+
     private boolean hasRead(final Supplier<ResponseEntity<?>> doCall) {
         try {
             final int statusCode = doCall.get().getStatusCode().value();

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/MainLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/MainLayout.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 import org.eclipse.hawkbit.ui.security.AuthenticatedUser;
 import org.eclipse.hawkbit.ui.view.AboutView;
+import org.eclipse.hawkbit.ui.view.AutoAssignmentView;
 import org.eclipse.hawkbit.ui.view.ConfigView;
 import org.eclipse.hawkbit.ui.view.DistributionSetView;
 import org.eclipse.hawkbit.ui.view.RolloutView;
@@ -61,6 +62,7 @@ public class MainLayout extends AppLayout {
 
     private static final List<Class<? extends Component>> DEFAULT_VIEW_PRIORITY = List.of(
             TargetView.class,
+            AutoAssignmentView.class,
             DistributionSetView.class,
             SoftwareModuleView.class,
             RolloutView.class,
@@ -131,6 +133,9 @@ public class MainLayout extends AppLayout {
         }
         if (accessChecker.hasAccess(RolloutView.class)) {
             nav.addItem(new SideNavItem("Rollouts", RolloutView.class, VaadinIcon.COGS.create()));
+        }
+        if (accessChecker.hasAccess(AutoAssignmentView.class)) {
+            nav.addItem(new SideNavItem("Auto Assignments", AutoAssignmentView.class, VaadinIcon.COGS.create()));
         }
         if (accessChecker.hasAccess(DistributionSetView.class)) {
             nav.addItem(new SideNavItem("Distribution Sets", DistributionSetView.class, VaadinIcon.FILE_TREE.create()));

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/security/GrantedAuthoritiesService.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/security/GrantedAuthoritiesService.java
@@ -49,6 +49,9 @@ public class GrantedAuthoritiesService {
         if (hawkbitClient.hasConfigRead()) {
             roles.add("CONFIG_READ");
         }
+        if (hawkbitClient.hasAutoAssignmentRead()) {
+            roles.add("AUTO_ASSIGNMENT_READ");
+        }
         return roles.stream().map(role -> new SimpleGrantedAuthority("ROLE_" + role)).toList();
     }
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/AutoAssignmentView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/AutoAssignmentView.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hawkbit.ui.view;
+
+import static com.vaadin.flow.component.icon.VaadinIcon.PAUSE;
+import static com.vaadin.flow.component.icon.VaadinIcon.START_COG;
+import static com.vaadin.flow.component.icon.VaadinIcon.TRASH;
+
+import java.io.Serial;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.datetimepicker.DateTimePicker;
+import com.vaadin.flow.component.dependency.Uses;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import org.eclipse.hawkbit.mgmt.json.model.autoassignment.MgmtAutoAssignmentResponseBody;
+import org.eclipse.hawkbit.mgmt.json.model.autoassignment.MgmtAutoAssignmentRestRequestBodyPost;
+import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
+import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtDistributionSet;
+import org.eclipse.hawkbit.mgmt.json.model.targetfilter.MgmtTargetFilterQuery;
+import org.eclipse.hawkbit.ui.HawkbitMgmtClient;
+import org.eclipse.hawkbit.ui.MainLayout;
+import org.eclipse.hawkbit.ui.view.util.Filter;
+import org.eclipse.hawkbit.ui.view.util.SelectionGrid;
+import org.eclipse.hawkbit.ui.view.util.TableView;
+import org.eclipse.hawkbit.ui.view.util.Utils;
+import org.springframework.util.ObjectUtils;
+
+@PageTitle("Auto Assignments")
+@Route(value = "auto_assignments", layout = MainLayout.class)
+@RolesAllowed({ "AUTO_ASSIGNMENT_READ" })
+@Uses(Icon.class)
+public final class AutoAssignmentView extends TableView<MgmtAutoAssignmentResponseBody, Long> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public AutoAssignmentView(final HawkbitMgmtClient hawkbitClient) {
+        super(
+                new AutoAssignmentFilter(),
+                new SelectionGrid.EntityRepresentation<MgmtAutoAssignmentResponseBody, Long>(
+                        MgmtAutoAssignmentResponseBody.class, MgmtAutoAssignmentResponseBody::getId) {
+
+                    private final AutoAssignmentDetails details = new AutoAssignmentDetails(hawkbitClient);
+                    @Override
+                    protected void addColumns(final Grid<MgmtAutoAssignmentResponseBody> grid) {
+                        grid.addColumn(MgmtAutoAssignmentResponseBody::getId).setHeader(Constants.ID).setAutoWidth(true);
+                        grid.addColumn(MgmtAutoAssignmentResponseBody::getName).setHeader(Constants.NAME).setAutoWidth(true);
+                        grid.addColumn(MgmtAutoAssignmentResponseBody::getStatus).setHeader(Constants.STATUS).setAutoWidth(true);
+
+                        grid.addComponentColumn(autoAssignment ->
+                                new Actions(autoAssignment, grid, hawkbitClient)).setHeader(Constants.ACTIONS).setAutoWidth(true);
+
+                        grid.setItemDetailsRenderer(new ComponentRenderer<>(
+                                () -> details, AutoAssignmentDetails::setItem));
+                    }
+                },
+                (query, rsqlFilter) -> Optional.ofNullable(
+                        hawkbitClient.getAutoAssignmentRestApi()
+                                .getAutoAssignments(
+                                        rsqlFilter,
+                                        query.getOffset(),
+                                        query.getPageSize(),
+                                        Constants.NAME_ASC
+                                ).getBody()).stream().flatMap(page -> page.getContent().stream()),
+                selectionGrid -> new CreateDialog(hawkbitClient).result(),
+                selectionGrid -> {
+                    selectionGrid.getSelectedItems().forEach(
+                            autoAssignment -> hawkbitClient.getAutoAssignmentRestApi().delete(autoAssignment.getId()));
+                    selectionGrid.refreshGrid(false);
+                    return CompletableFuture.completedFuture(null);
+                });
+        selectionGrid.getDataCommunicator().getKeyMapper().setIdentifierGetter(MgmtAutoAssignmentResponseBody::getId);
+    }
+
+    private static class Actions extends HorizontalLayout {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final long autoAssignmentId;
+        private final Grid<MgmtAutoAssignmentResponseBody> grid;
+        private final transient HawkbitMgmtClient hawkbitClient;
+
+        private Actions(final MgmtAutoAssignmentResponseBody autoAssignment, final Grid<MgmtAutoAssignmentResponseBody> grid,
+                final HawkbitMgmtClient hawkbitClient) {
+            this.autoAssignmentId = autoAssignment.getId();
+            this.grid = grid;
+            this.hawkbitClient = hawkbitClient;
+            init(autoAssignment);
+        }
+
+        private void init(final MgmtAutoAssignmentResponseBody autoAssignment) {
+            if("READY".equalsIgnoreCase(autoAssignment.getStatus())) {
+                add(Utils.tooltip(new Button(START_COG.create()) {
+
+                    {
+                        addClickListener(v -> {
+                            hawkbitClient.getAutoAssignmentRestApi().start(autoAssignment.getId());
+                            refresh();
+                        });
+                    }
+                }, "Start"));
+            } else if("RUNNING".equalsIgnoreCase(autoAssignment.getStatus())) {
+                add(Utils.tooltip(new Button(PAUSE.create()) {
+
+                    {
+                        addClickListener(v -> {
+                            hawkbitClient.getAutoAssignmentRestApi().pause(autoAssignment.getId());
+                            refresh();
+                        });
+                    }
+                }, "Pause"));
+            } else if("PAUSED".equalsIgnoreCase(autoAssignment.getStatus())) {
+                add(Utils.tooltip(new Button(START_COG.create()) {
+
+                    {
+                        addClickListener(v -> {
+                            hawkbitClient.getAutoAssignmentRestApi().resume(autoAssignment.getId());
+                            refresh();
+                        });
+                    }
+                }, "Resume"));
+            }
+            add(Utils.tooltip(new Button(TRASH.create()) {
+
+                {
+                    addClickListener(v -> Utils.confirmDialog("Confirm deletion",
+                            "Are you sure you want to delete the selected auto assignment? This action cannot be undone.",
+                            "Delete",
+                            () -> {
+                                hawkbitClient.getAutoAssignmentRestApi().delete(autoAssignment.getId());
+                                grid.getDataProvider().refreshAll();
+                            }).open()
+                    );
+                }
+            }, "Cancel and remove"));
+        }
+
+        private void refresh() {
+            final MgmtAutoAssignmentResponseBody body = hawkbitClient.getAutoAssignmentRestApi().getAutoAssignment(autoAssignmentId).getBody();
+            if(body != null) {
+                grid.getDataProvider().refreshItem(body);
+            }
+        }
+
+    }
+
+    private static class AutoAssignmentFilter implements Filter.Rsql {
+
+        private final TextField name = Utils.textField(Constants.NAME);
+
+        private AutoAssignmentFilter() {
+            name.setPlaceholder("<name filter>");
+        }
+
+        @Override
+        public List<Component> components() {
+            return List.of(name);
+        }
+
+        @Override
+        public String filter() {
+            return Filter.filter(Map.of("name", name.getOptionalValue()));
+        }
+    }
+
+    private static class AutoAssignmentDetails extends FormLayout {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final transient HawkbitMgmtClient hawkbitClient;
+
+        private final TextArea description = new TextArea(Constants.DESCRIPTION);
+        private final TextField createdBy = Utils.textField(Constants.CREATED_BY);
+        private final TextField createdAt = Utils.textField(Constants.CREATED_AT);
+        private final TextField lastModifiedBy = Utils.textField(Constants.LAST_MODIFIED_BY);
+        private final TextField lastModifiedAt = Utils.textField(Constants.LAST_MODIFIED_AT);
+        private final TextField targetFilter = Utils.textField(Constants.TARGET_FILTER);
+        private final TextField distributionSet = Utils.textField(Constants.DISTRIBUTION_SET);
+        private final TextField actonType = Utils.textField(Constants.ACTION_TYPE);
+        private final TextField startAt = Utils.textField(Constants.START_AT);
+
+
+        private AutoAssignmentDetails(final HawkbitMgmtClient hawkbitClient) {
+            this.hawkbitClient = hawkbitClient;
+
+            description.setMinLength(2);
+            Stream.of(
+                            description,
+                            createdBy, createdAt,
+                            lastModifiedBy, lastModifiedAt,
+                            targetFilter, distributionSet,
+                            actonType, startAt)
+                    .forEach(field -> {
+                        field.setReadOnly(true);
+                        add(field);
+                    });
+            setResponsiveSteps(new ResponsiveStep("0", 2));
+            setColspan(description, 2);
+        }
+
+        private void setItem(final MgmtAutoAssignmentResponseBody autoAssignment) {
+            description.setValue(Objects.requireNonNullElse(autoAssignment.getDescription(), ""));
+
+            createdBy.setValue(autoAssignment.getCreatedBy());
+            createdAt.setValue(Utils.localDateTimeFromTs(autoAssignment.getCreatedAt()));
+            lastModifiedBy.setValue(autoAssignment.getLastModifiedBy());
+            lastModifiedAt.setValue(Utils.localDateTimeFromTs(autoAssignment.getLastModifiedAt()));
+            targetFilter.setValue(autoAssignment.getTargetFilterQuery());
+            final MgmtDistributionSet distributionSetMgmt = hawkbitClient.getDistributionSetRestApi()
+                    .getDistributionSet(autoAssignment.getDistributionSetId()).getBody();
+            distributionSet.setValue(distributionSetMgmt == null
+                    ? NOT_AVAILABLE_NULL //should not be the case
+                    : distributionSetMgmt.getName() + ":" + distributionSetMgmt.getVersion());
+            actonType.setValue(switch (autoAssignment.getActionType()) {
+                case SOFT -> Constants.SOFT;
+                case FORCED -> Constants.FORCED;
+                case TIMEFORCED -> "";
+                case DOWNLOAD_ONLY -> Constants.DOWNLOAD_ONLY;
+            });
+            startAt.setValue(ObjectUtils.isEmpty(autoAssignment.getStartAt()) ? "" : Utils.localDateTimeFromTs(autoAssignment.getStartAt()));
+        }
+    }
+
+    private static class CreateDialog extends Utils.BaseDialog<Void> {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final TextField name;
+        private final TextArea description;
+        private final ComboBox<MgmtDistributionSet> distributionSet;
+        private final ComboBox<MgmtTargetFilterQuery> targetFilter;
+        private final Select<MgmtActionType> actionType;
+        private final DateTimePicker startAt = new DateTimePicker(Constants.START_AT);
+        private final Button create = new Button("Create");
+
+        private CreateDialog(final HawkbitMgmtClient hawkbitClient) {
+            super("Create Auto Assignment");
+
+            name = Utils.textField("Name", this::readyToCreate);
+            name.focus();
+            distributionSet = Utils.nameComboBox(
+                    "Distribution Set",
+                    this::readyToCreate,
+                    query -> hawkbitClient.getDistributionSetRestApi()
+                            .getDistributionSets(
+                                    query.getFilter().orElse(null),
+                                    query.getOffset(), query.getPageSize(), Constants.NAME_ASC, null)
+                            .getBody().getContent().stream());
+            distributionSet.setRequiredIndicatorVisible(true);
+            distributionSet.setItemLabelGenerator(distributionSet0 -> distributionSet0.getName() + ":" + distributionSet0.getVersion());
+            distributionSet.setWidthFull();
+            targetFilter = Utils.nameComboBox(
+                    "Target Filter",
+                    this::readyToCreate,
+                    query -> hawkbitClient.getTargetFilterQueryRestApi()
+                            .getFilters(query.getFilter().orElse(null), query.getOffset(), query.getPageSize(), Constants.NAME_ASC, null)
+                            .getBody().getContent().stream());
+            targetFilter.setRequiredIndicatorVisible(true);
+            targetFilter.setItemLabelGenerator(MgmtTargetFilterQuery::getName);
+            targetFilter.setWidthFull();
+            description = new TextArea(Constants.DESCRIPTION);
+            description.setMinLength(2);
+            description.setWidthFull();
+
+            actionType = Utils.actionTypeControls(
+                    new MgmtActionType[] { MgmtActionType.FORCED, MgmtActionType.SOFT, MgmtActionType.DOWNLOAD_ONLY },
+                    MgmtActionType.FORCED, null);
+
+            create.setEnabled(false);
+            create.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+            addCreateClickListener(hawkbitClient);
+            final Button cancel = Utils.tooltip(new Button(CANCEL), CANCEL_ESC);
+            cancel.addClickListener(e -> close());
+            cancel.addClickShortcut(Key.ESCAPE);
+            getFooter().add(cancel);
+            getFooter().add(create);
+
+            final VerticalLayout layout = new VerticalLayout();
+            layout.setSizeFull();
+            layout.setSpacing(false);
+            layout.add(name, distributionSet, targetFilter, description, actionType, startAt);
+            add(layout);
+            open();
+        }
+
+        private void readyToCreate(final Object v) {
+            final boolean createEnabled = !name.isEmpty() && !distributionSet.isEmpty() && !targetFilter.isEmpty();
+            if(create.isEnabled() != createEnabled) {
+                create.setEnabled(createEnabled);
+            }
+        }
+
+        private void addCreateClickListener(final HawkbitMgmtClient hawkbitClient) {
+            create.addClickListener(e -> {
+                close();
+                final MgmtAutoAssignmentRestRequestBodyPost request = new MgmtAutoAssignmentRestRequestBodyPost();
+                request.setName(name.getValue());
+                request.setDescription(description.getValue());
+                request.setDistributionSetId(distributionSet.getValue().getId());
+                request.setTargetFilterQuery(targetFilter.getValue().getQuery());
+
+                request.setActionType(actionType.getValue());
+                request.setStartAt(!startAt.isEmpty() ? startAt.getValue().toEpochSecond(ZoneOffset.UTC) * 1000 : null);
+                hawkbitClient.getAutoAssignmentRestApi().create(request);
+            });
+        }
+    }
+}

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/RolloutView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/RolloutView.java
@@ -105,6 +105,7 @@ public final class RolloutView extends TableView<MgmtRolloutResponseBody, Long> 
                     selectionGrid.refreshGrid(false);
                     return CompletableFuture.completedFuture(null);
                 });
+        selectionGrid.getDataCommunicator().getKeyMapper().setIdentifierGetter(MgmtRolloutResponseBody::getId);
     }
 
     private static class Actions extends HorizontalLayout {
@@ -199,7 +200,7 @@ public final class RolloutView extends TableView<MgmtRolloutResponseBody, Long> 
             removeAll();
             final MgmtRolloutResponseBody body = hawkbitClient.getRolloutRestApi().getRollout(rolloutId).getBody();
             if (body != null) {
-                init(body);
+                grid.getDataProvider().refreshItem(body);
             }
         }
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetFilterQueryView.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/view/TargetFilterQueryView.java
@@ -20,23 +20,18 @@ import java.util.stream.Stream;
 import jakarta.annotation.security.RolesAllowed;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.button.ButtonVariant;
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.tabs.TabSheet;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
@@ -44,12 +39,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.lumo.LumoUtility;
-import lombok.Getter;
 import org.eclipse.hawkbit.mgmt.json.model.PagedList;
-import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtActionType;
-import org.eclipse.hawkbit.mgmt.json.model.distributionset.MgmtDistributionSet;
-import org.eclipse.hawkbit.mgmt.json.model.targetfilter.MgmtDistributionSetAutoAssignment;
 import org.eclipse.hawkbit.mgmt.json.model.targetfilter.MgmtTargetFilterQuery;
 import org.eclipse.hawkbit.ui.HawkbitMgmtClient;
 import org.eclipse.hawkbit.ui.MainLayout;
@@ -84,8 +74,6 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
                         grid.addColumn(Utils.localDateTimeRenderer(MgmtTargetFilterQuery::getLastModifiedAt))
                                 .setHeader(Constants.LAST_MODIFIED_AT).setKey("lastModifiedAt").setSortable(true).setAutoWidth(true)
                                 .setResizable(true);
-                        grid.addColumn(new ComponentRenderer<>(DistributionSetCell::new))
-                                .setHeader(Constants.DISTRIBUTION_SET).setAutoWidth(true).setResizable(true);
 
                         grid.addComponentColumn(rollout -> new Actions(rollout, grid, hawkbitClient)).setHeader(
                                 Constants.ACTIONS).setAutoWidth(true);
@@ -100,7 +88,7 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
                         .stream()
                         .map(PagedList::getContent)
                         .flatMap(List::stream)
-                        .map(m -> TargetFilterQueryGridItem.from(hawkbitClient, m)),
+                        .map(m -> TargetFilterQueryGridItem.from(m)),
                 null,
                 selectionGrid -> {
                     selectionGrid.getSelectedItems()
@@ -152,37 +140,6 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
         }
     }
 
-    private static class DistributionSetCell extends HorizontalLayout {
-
-        private DistributionSetCell(final TargetFilterQueryGridItem filterQuery) {
-            filterQuery.getDs().ifPresent(ds -> {
-                Icon icon = getActionTypeIcon(filterQuery.getAutoAssignActionType());
-                icon.getStyle().setFlexShrink("0");
-
-                Span dsName = new Span(ds.getName() + ":" + ds.getVersion());
-                dsName.getStyle().setOverflow(Style.Overflow.HIDDEN);
-                dsName.getStyle().set("text-overflow", "ellipsis");
-                dsName.getStyle().setWhiteSpace(Style.WhiteSpace.NOWRAP);
-
-                add(icon, dsName);
-            });
-            setAlignItems(Alignment.CENTER);
-            setSpacing(true);
-            getStyle().setFlexWrap(Style.FlexWrap.NOWRAP);
-        }
-
-        private Icon getActionTypeIcon(MgmtActionType actionType) {
-            Icon icon = switch (actionType) {
-                case FORCED -> VaadinIcon.BOLT.create();
-                case SOFT -> VaadinIcon.USER_CHECK.create();
-                case DOWNLOAD_ONLY -> VaadinIcon.DOWNLOAD.create();
-                default -> VaadinIcon.QUESTION_CIRCLE.create();
-            };
-            icon.addClassNames(LumoUtility.IconSize.SMALL);
-            return Utils.tooltip(icon, actionType.getName());
-        }
-    }
-
     private static class Actions extends HorizontalLayout {
 
         private final Grid<TargetFilterQueryGridItem> grid;
@@ -196,26 +153,6 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
         }
 
         private void init(final MgmtTargetFilterQuery filter) {
-            if (filter.getAutoAssignDistributionSet() == null) {
-                Button autoAssignButton = new Button(VaadinIcon.LINK.create());
-                autoAssignButton.addClickListener(e ->
-                        new AutoAssignDialog(filter.getId(), hawkbitClient, () -> refresh(filter.getId())).open()
-                );
-                add(Utils.tooltip(autoAssignButton, "Auto assign"));
-            } else {
-                Button unassignButton = new Button(VaadinIcon.UNLINK.create());
-                unassignButton.addClickListener(e -> {
-                    ConfirmDialog dialog = Utils.confirmDialog("Unassign Distribution Set",
-                            "Are you sure you want to unassign the distribution set of target filter query '" + filter.getName() + "'?",
-                            "Unassign",
-                            () -> {
-                                hawkbitClient.getTargetFilterQueryRestApi().deleteAssignedDistributionSet(filter.getId());
-                                refresh(filter.getId());
-                            });
-                    dialog.open();
-                });
-                add(Utils.tooltip(unassignButton, "Unassign"));
-            }
             Button deleteButton = new Button(VaadinIcon.TRASH.create());
             deleteButton.addClickListener(e -> {
                 ConfirmDialog dialog = Utils.confirmDialog("Confirm Deletion",
@@ -228,84 +165,6 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
                 dialog.open();
             });
             add(Utils.tooltip(deleteButton, "Delete"));
-        }
-
-        private void refresh(Long filterId) {
-            removeAll();
-            final MgmtTargetFilterQuery body = hawkbitClient.getTargetFilterQueryRestApi().getFilter(filterId).getBody();
-            if (body != null) {
-                grid.getDataProvider().refreshItem(TargetFilterQueryGridItem.from(hawkbitClient, body));
-                init(body);
-            }
-        }
-    }
-
-    private static class AutoAssignDialog extends Utils.BaseDialog<Void> {
-
-        private final Long filterId;
-        private final Select<MgmtActionType> actionType;
-        private final ComboBox<MgmtDistributionSet> distributionSet;
-        private final Button assign = new Button("Assign");
-
-        private AutoAssignDialog(final Long filterId, final HawkbitMgmtClient hawkbitClient, Runnable onSuccess) {
-            super("Select auto assignment distribution set");
-
-            this.filterId = filterId;
-
-            Paragraph description = new Paragraph("When an auto assign distribution set is selected, " +
-                    "it will be automatically assigned to all targets that match the target filter.");
-
-            actionType = Utils.actionTypeControls(
-                    new MgmtActionType[] {
-                            MgmtActionType.SOFT, MgmtActionType.FORCED, MgmtActionType.DOWNLOAD_ONLY }, MgmtActionType.FORCED, null);
-
-            distributionSet = Utils.nameComboBox("Distribution Set", this::readyToAssign, query -> Optional.ofNullable(
-                    hawkbitClient.getDistributionSetRestApi()
-                            .getDistributionSets(
-                                    query.getFilter().orElse(null),
-                                    query.getOffset(),
-                                    query.getLimit(),
-                                    Constants.NAME_ASC,
-                                    null)
-                            .getBody()).stream().flatMap(body -> body.getContent().stream()));
-            distributionSet.setItemLabelGenerator(ds -> ds.getName() + ":" + ds.getVersion());
-            distributionSet.focus();
-            distributionSet.setRequiredIndicatorVisible(true);
-            distributionSet.setWidthFull();
-
-            assign.setEnabled(false);
-            assign.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-            addAssignClickListener(hawkbitClient, onSuccess);
-            final Button cancel = Utils.tooltip(new Button(CANCEL), CANCEL_ESC);
-            cancel.addClickListener(e -> close());
-            cancel.addClickShortcut(Key.ESCAPE);
-            getFooter().add(cancel);
-            getFooter().add(assign);
-
-            final VerticalLayout layout = new VerticalLayout();
-            layout.setSizeFull();
-            layout.setSpacing(false);
-            layout.add(description, actionType, distributionSet);
-            add(layout);
-            open();
-        }
-
-        private void readyToAssign(final Object v) {
-            final boolean createEnabled = !distributionSet.isEmpty();
-            if (assign.isEnabled() != createEnabled) {
-                assign.setEnabled(createEnabled);
-            }
-        }
-
-        private void addAssignClickListener(final HawkbitMgmtClient hawkbitClient, Runnable onSuccess) {
-            assign.addClickListener(e -> {
-                MgmtDistributionSetAutoAssignment newAssignment = new MgmtDistributionSetAutoAssignment();
-                newAssignment.setId(distributionSet.getValue().getId());
-                newAssignment.setType(actionType.getValue());
-                hawkbitClient.getTargetFilterQueryRestApi().postAssignedDistributionSet(filterId, newAssignment);
-                onSuccess.run();
-                close();
-            });
         }
     }
 
@@ -340,19 +199,13 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
         private final TextField createdAt = Utils.textField(Constants.CREATED_AT);
         private final TextField lastModifiedBy = Utils.textField(Constants.LAST_MODIFIED_BY);
         private final TextField lastModifiedAt = Utils.textField(Constants.LAST_MODIFIED_AT);
-        private final TextField autoAssignDistributionSet = Utils.textField("Auto Assign Distribution Set");
-        private final TextField autoAssignActionType = Utils.textField("Auto Assign Action Type");
-        private final TextField autoAssignWeight = Utils.textField("Auto Assign Weight");
-        private final TextField confirmationRequired = Utils.textField("Confirmation Required");
 
         private TargetFilterQueryDetails() {
             query.setMinLength(2);
             Stream.of(
                             name, query,
                             createdBy, createdAt,
-                            lastModifiedBy, lastModifiedAt,
-                            autoAssignDistributionSet, autoAssignActionType,
-                            autoAssignWeight, confirmationRequired)
+                            lastModifiedBy, lastModifiedAt)
                     .forEach(field -> {
                         field.setReadOnly(true);
                         add(field);
@@ -369,42 +222,19 @@ public class TargetFilterQueryView extends TableView<TargetFilterQueryView.Targe
             createdAt.setValue(Utils.localDateTimeFromTs(filterQuery.getCreatedAt()));
             lastModifiedBy.setValue(filterQuery.getLastModifiedBy() != null ? filterQuery.getLastModifiedBy() : "");
             lastModifiedAt.setValue(Utils.localDateTimeFromTs(filterQuery.getLastModifiedAt()));
-
-            filterQuery.getDs().ifPresentOrElse(
-                    ds -> autoAssignDistributionSet.setValue(ds.getName() + ":" + ds.getVersion()),
-                    () -> autoAssignDistributionSet.setValue("")
-            );
-            autoAssignActionType.setValue(filterQuery.getAutoAssignActionType() != null ?
-                    filterQuery.getAutoAssignActionType().getName() : "");
-            autoAssignWeight.setValue(filterQuery.getAutoAssignWeight() != null ?
-                    filterQuery.getAutoAssignWeight().toString() : "");
-            confirmationRequired.setValue(filterQuery.getConfirmationRequired() != null ?
-                    filterQuery.getConfirmationRequired().toString() : "");
         }
     }
 
-    // TODO - change /targetfilters api to reduce api calls ?
-    @Getter
     public static class TargetFilterQueryGridItem extends MgmtTargetFilterQuery {
 
         TargetFilterQueryGridItem() {
             super();
         }
 
-        private Optional<MgmtDistributionSet> ds;
         private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-        public static TargetFilterQueryGridItem from(final HawkbitMgmtClient hawkbitClient, MgmtTargetFilterQuery filter) {
-            TargetFilterQueryGridItem filterGridItem = OBJECT_MAPPER.convertValue(filter, TargetFilterQueryGridItem.class);
-
-            if (filterGridItem.getAutoAssignDistributionSet() != null) {
-                filterGridItem.ds = Optional.ofNullable(
-                        hawkbitClient.getTargetFilterQueryRestApi().getAssignedDistributionSet(filterGridItem.getId()).getBody()
-                );
-            } else {
-                filterGridItem.ds = Optional.empty();
-            }
-            return filterGridItem;
+        public static TargetFilterQueryGridItem from(   MgmtTargetFilterQuery filter) {
+            return OBJECT_MAPPER.convertValue(filter, TargetFilterQueryGridItem.class);
         }
 
         @Override


### PR DESCRIPTION
## What 
Created an Auto Assignment View for the Hawkbit UI, removed obsolete fields from the Target Filter Query View. Also updated Rollouts View to directly update the status on action performed

## Changes
- Created an `AutoAssignmentView` based on the `RolloutsView`
- Updated `TargetFilterQueryView` so that it no longer has a link to auto assignments and does not use any deprecated methods
- Updated `RolloutView` so that on start/pause/resume the status as well as the icon changes without needing a refresh
- Added a permission for reading auto assignments
- Updated the `MgmtAutoAssignmentMapper` so it now includes createdAt/By and lastModifiedAt/By and maps them