### PR TITLE
DistributionSetTypeElement#smType now Lazy - loaded only on demand

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
@@ -10,6 +10,7 @@
 package org.eclipse.hawkbit.repository.model;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A {@link DistributionSetType} is an abstract definition for {@link DistributionSet} that defines what {@link SoftwareModule}s can be
@@ -30,6 +31,22 @@ public interface DistributionSetType extends Type {
     Set<SoftwareModuleType> getOptionalModuleTypes();
 
     /**
+     * @return ids of the mandatory {@link SoftwareModuleType}s. Implementations should serve these without loading the
+     *         full {@link SoftwareModuleType} entities where possible (id-only, storm-free).
+     */
+    default Set<Long> getMandatoryModuleTypeIds() {
+        return getMandatoryModuleTypes().stream().map(SoftwareModuleType::getId).collect(Collectors.toSet());
+    }
+
+    /**
+     * @return ids of the optional {@link SoftwareModuleType}s. Implementations should serve these without loading the
+     *         full {@link SoftwareModuleType} entities where possible (id-only, storm-free).
+     */
+    default Set<Long> getOptionalModuleTypeIds() {
+        return getOptionalModuleTypes().stream().map(SoftwareModuleType::getId).collect(Collectors.toSet());
+    }
+
+    /**
      * Checks if the given {@link SoftwareModuleType} is in this {@link DistributionSetType}.
      *
      * @param softwareModuleType search for
@@ -46,7 +63,7 @@ public interface DistributionSetType extends Type {
      * @return <code>true</code> if found
      */
     default boolean containsMandatoryModuleType(final SoftwareModuleType softwareModuleType) {
-        return getMandatoryModuleTypes().stream().anyMatch(element -> element.getId().equals(softwareModuleType.getId()));
+        return getMandatoryModuleTypeIds().contains(softwareModuleType.getId());
     }
 
     /**
@@ -56,6 +73,6 @@ public interface DistributionSetType extends Type {
      * @return <code>true</code> if found
      */
     default boolean containsOptionalModuleType(final SoftwareModuleType softwareModuleType) {
-        return getOptionalModuleTypes().stream().anyMatch(element -> element.getId().equals(softwareModuleType.getId()));
+        return getOptionalModuleTypeIds().contains(softwareModuleType.getId());
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DistributionSetType.java
@@ -34,17 +34,13 @@ public interface DistributionSetType extends Type {
      * @return ids of the mandatory {@link SoftwareModuleType}s. Implementations should serve these without loading the
      *         full {@link SoftwareModuleType} entities where possible (id-only, storm-free).
      */
-    default Set<Long> getMandatoryModuleTypeIds() {
-        return getMandatoryModuleTypes().stream().map(SoftwareModuleType::getId).collect(Collectors.toSet());
-    }
+    Set<Long> getMandatoryModuleTypeIds();
 
     /**
      * @return ids of the optional {@link SoftwareModuleType}s. Implementations should serve these without loading the
      *         full {@link SoftwareModuleType} entities where possible (id-only, storm-free).
      */
-    default Set<Long> getOptionalModuleTypeIds() {
-        return getOptionalModuleTypes().stream().map(SoftwareModuleType::getId).collect(Collectors.toSet());
-    }
+    Set<Long> getOptionalModuleTypeIds();
 
     /**
      * Checks if the given {@link SoftwareModuleType} is in this {@link DistributionSetType}.

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/DistributionSetTypeElement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/DistributionSetTypeElement.java
@@ -73,14 +73,12 @@ public class DistributionSetTypeElement {
      *             additional query (does not resolve the {@link SoftwareModuleType} entity).
      */
     public Long getSmTypeId() {
-        return key == null ? null : key.getSmType();
+        return key.getSmType();
     }
 
     @Override
     public String toString() {
-        return "DistributionSetTypeElement [mandatory=" + mandatory + ", dsTypeId=" + (key == null
-                ? null
-                : key.getDsType()) + ", smTypeId=" + (key == null ? null : key.getSmType()) + "]";
+        return "DistributionSetTypeElement [mandatory=" + mandatory + ", dsTypeId=" + key.getDsType() + ", smTypeId=" + key.getSmType() + "]";
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/DistributionSetTypeElement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/DistributionSetTypeElement.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
@@ -44,9 +45,8 @@ public class DistributionSetTypeElement {
     private JpaDistributionSetType dsType;
 
     @Getter
-    @MapsId("smType")
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "software_module_type", nullable = false, updatable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "software_module_type", nullable = false, insertable = false, updatable = false)
     private JpaSoftwareModuleType smType;
 
     @Setter
@@ -68,9 +68,19 @@ public class DistributionSetTypeElement {
         this.mandatory = mandatory;
     }
 
+    /**
+     * @return the id of the referenced {@link SoftwareModuleType}, read directly from the composite key with no
+     *             additional query (does not resolve the {@link SoftwareModuleType} entity).
+     */
+    public Long getSmTypeId() {
+        return key == null ? null : key.getSmType();
+    }
+
     @Override
     public String toString() {
-        return "DistributionSetTypeElement [mandatory=" + mandatory + ", dsType=" + dsType + ", smType=" + smType + "]";
+        return "DistributionSetTypeElement [mandatory=" + mandatory + ", dsTypeId=" + (key == null
+                ? null
+                : key.getDsType()) + ", smTypeId=" + (key == null ? null : key.getSmType()) + "]";
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSet.java
@@ -12,10 +12,10 @@ package org.eclipse.hawkbit.repository.jpa.model;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -47,7 +47,6 @@ import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.DistributionSetTag;
 import org.eclipse.hawkbit.repository.model.DistributionSetType;
 import org.eclipse.hawkbit.repository.model.SoftwareModule;
-import org.eclipse.hawkbit.repository.model.SoftwareModuleType;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.core.annotation.Order;
 
@@ -148,11 +147,10 @@ public class JpaDistributionSet
             if (getModules().stream().anyMatch(module -> !module.isComplete())) {
                 return false; // incomplete module
             }
-            final List<SoftwareModuleType> smTypes = getModules().stream()
-                    .map(SoftwareModule::getType)
-                    .distinct()
-                    .toList();
-            return !smTypes.isEmpty() && new HashSet<>(smTypes).containsAll(dsType.getMandatoryModuleTypes());
+            final Set<Long> moduleTypeIds = getModules().stream()
+                    .map(module -> module.getType().getId())
+                    .collect(Collectors.toSet());
+            return !moduleTypeIds.isEmpty() && moduleTypeIds.containsAll(dsType.getMandatoryModuleTypeIds());
         }).orElse(true);
     }
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaDistributionSetType.java
@@ -76,6 +76,22 @@ public class JpaDistributionSetType extends AbstractJpaTypeEntity implements Dis
                 .collect(Collectors.toSet());
     }
 
+    @Override
+    public Set<Long> getMandatoryModuleTypeIds() {
+        return elements.stream()
+                .filter(DistributionSetTypeElement::isMandatory)
+                .map(DistributionSetTypeElement::getSmTypeId)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Long> getOptionalModuleTypeIds() {
+        return elements.stream()
+                .filter(element -> !element.isMandatory())
+                .map(DistributionSetTypeElement::getSmTypeId)
+                .collect(Collectors.toSet());
+    }
+
     public JpaDistributionSetType setMandatoryModuleTypes(final Set<SoftwareModuleType> smType) {
         return replaceOrAddModuleTypes(smType, true, true);
     }
@@ -94,7 +110,7 @@ public class JpaDistributionSetType extends AbstractJpaTypeEntity implements Dis
 
     public JpaDistributionSetType removeModuleType(final SoftwareModuleType smType) {
         elements.stream()
-                .filter(element -> smType.getId().equals(element.getSmType().getId()))
+                .filter(element -> smType.getId().equals(element.getSmTypeId()))
                 .toList() // collect to a list to avoid ConcurrentModificationException
                 .forEach(element -> elements.remove(element));
         return this;
@@ -142,7 +158,7 @@ public class JpaDistributionSetType extends AbstractJpaTypeEntity implements Dis
                     .map(SoftwareModuleType::getId)
                     .collect(Collectors.toSet());
             elements.stream()
-                    .filter(element -> element.isMandatory() == mandatory && !smTypeIds.contains(element.getSmType().getId()))
+                    .filter(element -> element.isMandatory() == mandatory && !smTypeIds.contains(element.getSmTypeId()))
                     .collect(Collectors.toSet())
                     .forEach(element -> elements.remove(element));
         }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/AbstractTypeManagementCacheAcmTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/AbstractTypeManagementCacheAcmTest.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.hawkbit.repository.jpa.acm;
 
-import org.eclipse.hawkbit.repository.test.util.QueryCount;
+import org.eclipse.hawkbit.repository.test.util.QueryUtil;
 import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
 import org.eclipse.hawkbit.tenancy.TenantAwareCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
  * caller is rejected without a DB hit.
  * <p>
  * Enables a real cache (test defaults set {@code maximumSize=0}, a NOP cache, which would defeat these assertions) and
- * counts SQL via a provider-agnostic JDBC recorder ({@link QueryCount}), so the same assertions hold under both
+ * counts SQL via a provider-agnostic JDBC recorder ({@link QueryUtil}), so the same assertions hold under both
  * EclipseLink and Hibernate.
  */
 @Import(QueryCountConfiguration.class)
@@ -36,7 +36,7 @@ import org.springframework.test.context.TestPropertySource;
 abstract class AbstractTypeManagementCacheAcmTest extends AbstractAccessControllerManagementTest {
 
     @Autowired
-    private QueryCount queryCount;
+    private QueryUtil queryUtil;
 
     /** Evicts the given id from the by-id cache named after the entity class' simple name. */
     protected void evict(final String cacheName, final Long id) {
@@ -45,6 +45,6 @@ abstract class AbstractTypeManagementCacheAcmTest extends AbstractAccessControll
 
     /** Cumulative count of {@code SELECT} statements sent to the DB - use deltas around the measured section. */
     protected long readQueries() {
-        return queryCount.selects();
+        return queryUtil.countSelectQueries();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/AbstractTypeManagementCacheAcmTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/AbstractTypeManagementCacheAcmTest.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.hawkbit.repository.jpa.acm;
 
-import org.eclipse.hawkbit.repository.test.util.QueryUtil;
+import org.eclipse.hawkbit.repository.test.util.QueryCount;
 import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
 import org.eclipse.hawkbit.tenancy.TenantAwareCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
  * caller is rejected without a DB hit.
  * <p>
  * Enables a real cache (test defaults set {@code maximumSize=0}, a NOP cache, which would defeat these assertions) and
- * counts SQL via a provider-agnostic JDBC recorder ({@link QueryUtil}), so the same assertions hold under both
+ * counts SQL via a provider-agnostic JDBC recorder ({@link QueryCount}), so the same assertions hold under both
  * EclipseLink and Hibernate.
  */
 @Import(QueryCountConfiguration.class)
@@ -36,7 +36,7 @@ import org.springframework.test.context.TestPropertySource;
 abstract class AbstractTypeManagementCacheAcmTest extends AbstractAccessControllerManagementTest {
 
     @Autowired
-    private QueryUtil queryUtil;
+    private QueryCount queryCount;
 
     /** Evicts the given id from the by-id cache named after the entity class' simple name. */
     protected void evict(final String cacheName, final Long id) {
@@ -45,6 +45,6 @@ abstract class AbstractTypeManagementCacheAcmTest extends AbstractAccessControll
 
     /** Cumulative count of {@code SELECT} statements sent to the DB - use deltas around the measured section. */
     protected long readQueries() {
-        return queryUtil.countSelectQueries();
+        return queryCount.countSelect();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/AbstractTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/AbstractTypeManagementCacheTest.java
@@ -10,8 +10,8 @@
 package org.eclipse.hawkbit.repository.jpa.management;
 
 import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
+import org.eclipse.hawkbit.repository.test.util.QueryCount;
 import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
-import org.eclipse.hawkbit.repository.test.util.QueryUtil;
 import org.eclipse.hawkbit.tenancy.TenantAwareCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -19,7 +19,7 @@ import org.springframework.test.context.TestPropertySource;
 
 /**
  * Base for the per-type by-id cache tests (no ACM). Enables a real cache for the cached type management services and
- * opts in to the provider-agnostic SQL recorder ({@link QueryUtil}) via {@link QueryCountConfiguration}, exposing it as
+ * opts in to the provider-agnostic SQL recorder ({@link QueryCount}) via {@link QueryCountConfiguration}, exposing it as
  * the {@code queryUtil} field ({@code resetQueries()}, {@code countSelectQueries()}, {@code countSelectsFromTable(..)},
  * {@code getAllQueries()}). Only {@link #evict(String, Long)} is specific to these tests.
  * <p>
@@ -37,7 +37,7 @@ import org.springframework.test.context.TestPropertySource;
 abstract class AbstractTypeManagementCacheTest extends AbstractJpaIntegrationTest {
 
     @Autowired
-    protected QueryUtil queryUtil;
+    protected QueryCount queryCount;
 
     /** Evicts the given id from the by-id cache named after the entity class' simple name. */
     protected void evict(final String cacheName, final Long id) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/AbstractTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/AbstractTypeManagementCacheTest.java
@@ -10,8 +10,8 @@
 package org.eclipse.hawkbit.repository.jpa.management;
 
 import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
-import org.eclipse.hawkbit.repository.test.util.QueryCount;
 import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
+import org.eclipse.hawkbit.repository.test.util.QueryUtil;
 import org.eclipse.hawkbit.tenancy.TenantAwareCacheManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -19,8 +19,9 @@ import org.springframework.test.context.TestPropertySource;
 
 /**
  * Base for the per-type by-id cache tests (no ACM). Enables a real cache for the cached type management services and
- * counts SQL via a provider-agnostic JDBC recorder ({@link QueryCount}), so the same assertions hold under both
- * EclipseLink and Hibernate.
+ * opts in to the provider-agnostic SQL recorder ({@link QueryUtil}) via {@link QueryCountConfiguration}, exposing it as
+ * the {@code queryUtil} field ({@code resetQueries()}, {@code countSelectQueries()}, {@code countSelectsFromTable(..)},
+ * {@code getAllQueries()}). Only {@link #evict(String, Long)} is specific to these tests.
  * <p>
  * A dedicated class hierarchy (rather than folding these into the per-type {@code *ManagementTest} classes) is required
  * because the real-cache specs below are class-level and must not change caching semantics for the unrelated
@@ -36,15 +37,10 @@ import org.springframework.test.context.TestPropertySource;
 abstract class AbstractTypeManagementCacheTest extends AbstractJpaIntegrationTest {
 
     @Autowired
-    private QueryCount queryCount;
+    protected QueryUtil queryUtil;
 
     /** Evicts the given id from the by-id cache named after the entity class' simple name. */
     protected void evict(final String cacheName, final Long id) {
         TenantAwareCacheManager.getInstance().getCache(cacheName).evict(id);
-    }
-
-    /** Cumulative count of {@code SELECT} statements sent to the DB - use deltas around the measured section. */
-    protected long readQueries() {
-        return queryCount.selects();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementCacheTest.java
@@ -25,48 +25,27 @@ class DistributionSetTypeManagementCacheTest extends AbstractTypeManagementCache
 
     /**
      * Scenario: evict, then read the same DSType six times.
-     * Proves: only the first read (cache miss) hits the DB; the next five are served from cache — 0 queries —
-     * eliminating the repeated DSType + N×SoftwareModuleType query storm that motivated the cache.
-     * <p/>
-     * Note: a single miss still issues several queries — EclipseLink resolves each element's smType
-     * {@code @ManyToOne} with its own ReadObjectQuery, which JOIN FETCH / an entity graph cannot collapse. That
-     * per-miss cost is inherent and amortized by the cache; the point is it happens once per entity, not per request.
+     * Proves two things: (1) the cold miss loads the DS-type WITHOUT the {@code sp_software_module_type} by-id storm -
+     * since {@code DistributionSetTypeElement.smType} is no longer {@code @MapsId}, materialising the elements no longer
+     * pulls one {@code SoftwareModuleType} entity per element; (2) the next five reads are served from the by-id cache
+     * (0 queries). Before the fix the miss issued 1 DSType + 1 element + N smType by-id selects; now it issues no smType
+     * by-id at all. Provider-agnostic (the storm was EclipseLink-only; Hibernate already joined - both now yield 0).
      */
     @Test
-    void verifyRepeatedReadsOnlyMissHitsDb() {
+    void missLoadsTypeWithoutModuleTypeStormThenReadsAreCached() {
         evict(JpaDistributionSetType.class.getSimpleName(), standardDsType.getId());
 
-        final long beforeMiss = readQueries();
-        distributionSetTypeManagement.get(standardDsType.getId()); // miss — hits DB
-        assertThat(readQueries() - beforeMiss)
-                .as("cache miss must load from DB")
-                .isPositive();
+        queryUtil.resetQueries();
+        distributionSetTypeManagement.get(standardDsType.getId()); // cache miss -> DB
+        assertThat(queryUtil.countSelectQueries()).as("cache miss must load from DB").isPositive();
+        assertThat(queryUtil.countSelectsFromTable("sp_software_module_type"))
+                .as("loading a DS-type must NOT storm sp_software_module_type by-id (element smType is no longer @MapsId)")
+                .isZero();
 
-        final long beforeHits = readQueries();
+        queryUtil.resetQueries();
         for (int i = 0; i < 5; i++) {
             distributionSetTypeManagement.get(standardDsType.getId()); // all served from cache
         }
-        assertThat(readQueries() - beforeHits)
-                .as("repeated reads must be served from cache — 0 DB queries")
-                .isZero();
-    }
-
-    /**
-     * Scenario: load a DSType on a cold cache, then walk its mandatory/optional module types.
-     * Proves: the cached entity is complete — elements and their smTypes are fetched eagerly during the load, so
-     * navigating them afterwards triggers no extra query (no lazy N+1 hidden behind the cache).
-     * The default test DS type has 1 mandatory (os) and 2 optional (runtime, app) module types.
-     */
-    @Test
-    void verifyCachedEntityModuleTypesAccessibleWithoutQuery() {
-        evict(JpaDistributionSetType.class.getSimpleName(), standardDsType.getId());
-        final DistributionSetType loaded = distributionSetTypeManagement.get(standardDsType.getId());
-
-        final long before = readQueries();
-        assertThat(loaded.getMandatoryModuleTypes()).hasSize(1); // os
-        assertThat(loaded.getOptionalModuleTypes()).hasSize(2); // runtime + app
-        assertThat(readQueries() - before)
-                .as("module types on the fully-loaded cached entity must not hit DB")
-                .isZero();
+        assertThat(queryUtil.countSelectQueries()).as("repeated reads must be served from cache - 0 DB queries").isZero();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementCacheTest.java
@@ -35,17 +35,17 @@ class DistributionSetTypeManagementCacheTest extends AbstractTypeManagementCache
     void missLoadsTypeWithoutModuleTypeStormThenReadsAreCached() {
         evict(JpaDistributionSetType.class.getSimpleName(), standardDsType.getId());
 
-        queryUtil.resetQueries();
+        queryCount.resetQueries();
         distributionSetTypeManagement.get(standardDsType.getId()); // cache miss -> DB
-        assertThat(queryUtil.countSelectQueries()).as("cache miss must load from DB").isPositive();
-        assertThat(queryUtil.countSelectsFromTable("sp_software_module_type"))
+        assertThat(queryCount.countSelect()).as("cache miss must load from DB").isPositive();
+        assertThat(queryCount.countSelectsFromTable("sp_software_module_type"))
                 .as("loading a DS-type must NOT storm sp_software_module_type by-id (element smType is no longer @MapsId)")
                 .isZero();
 
-        queryUtil.resetQueries();
+        queryCount.resetQueries();
         for (int i = 0; i < 5; i++) {
             distributionSetTypeManagement.get(standardDsType.getId()); // all served from cache
         }
-        assertThat(queryUtil.countSelectQueries()).as("repeated reads must be served from cache - 0 DB queries").isZero();
+        assertThat(queryCount.countSelect()).as("repeated reads must be served from cache - 0 DB queries").isZero();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementTest.java
@@ -38,8 +38,8 @@ import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
+import org.eclipse.hawkbit.repository.test.util.QueryCount;
 import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
-import org.eclipse.hawkbit.repository.test.util.QueryUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -56,7 +56,7 @@ class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest
     public static final String USED_BY_DS_TYPE_KEY = "updatableType";
 
     @Autowired
-    private QueryUtil queryUtil;
+    private QueryCount queryCount;
 
     /**
      * Tests the successful module update of unused distribution set type which is in fact allowed.
@@ -249,12 +249,12 @@ class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest
     void loadingTypeAndReadingModuleTypeIdsIssuesNoSoftwareModuleTypeQuery() {
         final long typeId = defaultDsType().getId();
 
-        queryUtil.resetQueries();
+        queryCount.resetQueries();
         final DistributionSetType type = distributionSetTypeManagement.get(typeId);
         type.getMandatoryModuleTypeIds();
         type.getOptionalModuleTypeIds();
 
-        assertThat(queryUtil.countSelectsFromTable("sp_software_module_type")).isZero();
+        assertThat(queryCount.countSelectsFromTable("sp_software_module_type")).isZero();
     }
 
     private void createAndUpdateDistributionSetWithInvalidDescription(final DistributionSet set) {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DistributionSetTypeManagementTest.java
@@ -38,7 +38,11 @@ import org.eclipse.hawkbit.repository.model.NamedEntity;
 import org.eclipse.hawkbit.repository.model.NamedVersionedEntity;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
+import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
+import org.eclipse.hawkbit.repository.test.util.QueryUtil;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
  * {@link DistributionSetManagement} tests.
@@ -46,9 +50,13 @@ import org.junit.jupiter.api.Test;
  * Feature: Component Tests - Repository<br/>
  * Story: DistributionSet Management
  */
+@Import(QueryCountConfiguration.class)
 class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest<DistributionSetType, Create, Update> {
 
     public static final String USED_BY_DS_TYPE_KEY = "updatableType";
+
+    @Autowired
+    private QueryUtil queryUtil;
 
     /**
      * Tests the successful module update of unused distribution set type which is in fact allowed.
@@ -233,6 +241,22 @@ class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest
                 .isInstanceOf(EntityReadOnlyException.class);
     }
 
+    /**
+     * Loading a distribution set type and reading its module-type ids issues no {@code sp_software_module_type} query -
+     * the ids are served from the type element composite keys, without materialising the module type entities.
+     */
+    @Test
+    void loadingTypeAndReadingModuleTypeIdsIssuesNoSoftwareModuleTypeQuery() {
+        final long typeId = defaultDsType().getId();
+
+        queryUtil.resetQueries();
+        final DistributionSetType type = distributionSetTypeManagement.get(typeId);
+        type.getMandatoryModuleTypeIds();
+        type.getOptionalModuleTypeIds();
+
+        assertThat(queryUtil.countSelectsFromTable("sp_software_module_type")).isZero();
+    }
+
     private void createAndUpdateDistributionSetWithInvalidDescription(final DistributionSet set) {
         final DistributionSetManagement.Create distributionSetCreate = DistributionSetManagement.Create.builder()
                 .name("a").version("a").description(randomString(513)).build();
@@ -322,8 +346,8 @@ class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest
                 .as("set with too short version should not be created")
                 .isThrownBy(() -> distributionSetManagement.create(distributionSetCreate3));
 
-        final DistributionSetManagement.Create distributionSetCreate4 =
-                DistributionSetManagement.Create.builder().name("a").version(null).build();
+        final DistributionSetManagement.Create distributionSetCreate4 = DistributionSetManagement.Create.builder().name("a").version(null)
+                .build();
         assertThatExceptionOfType(ConstraintViolationException.class)
                 .as("set with null version should not be created")
                 .isThrownBy(() -> distributionSetManagement.create(distributionSetCreate4));
@@ -334,14 +358,14 @@ class DistributionSetTypeManagementTest extends AbstractRepositoryManagementTest
                 .as("set with too long version should not be updated")
                 .isThrownBy(() -> distributionSetManagement.update(distributionSetUpdate));
 
-        final DistributionSetManagement.Update distributionSetUpdate2 =
-                DistributionSetManagement.Update.builder().id(set.getId()).version(INVALID_TEXT_HTML).build();
+        final DistributionSetManagement.Update distributionSetUpdate2 = DistributionSetManagement.Update.builder().id(set.getId()).version(
+                INVALID_TEXT_HTML).build();
         assertThatExceptionOfType(ConstraintViolationException.class)
                 .as("set with invalid version should not be updated")
                 .isThrownBy(() -> distributionSetManagement.update(distributionSetUpdate2));
 
-        final DistributionSetManagement.Update distributionSetUpdate3 =
-                DistributionSetManagement.Update.builder().id(set.getId()).version("").build();
+        final DistributionSetManagement.Update distributionSetUpdate3 = DistributionSetManagement.Update.builder().id(set.getId()).version("")
+                .build();
         assertThatExceptionOfType(ConstraintViolationException.class)
                 .as("set with too short version should not be updated")
                 .isThrownBy(() -> distributionSetManagement.update(distributionSetUpdate3));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/SoftwareModuleTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/SoftwareModuleTypeManagementCacheTest.java
@@ -29,15 +29,15 @@ class SoftwareModuleTypeManagementCacheTest extends AbstractTypeManagementCacheT
     void verifySoftwareModuleTypeCacheMissThenHit() {
         evict(JpaSoftwareModuleType.class.getSimpleName(), osType.getId());
 
-        final long afterEvict = readQueries();
+        final long afterEvict = queryUtil.countSelectQueries();
         softwareModuleTypeManagement.get(osType.getId()); // miss
-        assertThat(readQueries() - afterEvict)
+        assertThat(queryUtil.countSelectQueries() - afterEvict)
                 .as("SMType cache miss must produce exactly 1 query")
                 .isEqualTo(1);
 
-        final long afterMiss = readQueries();
+        final long afterMiss = queryUtil.countSelectQueries();
         softwareModuleTypeManagement.get(osType.getId()); // hit
-        assertThat(readQueries() - afterMiss)
+        assertThat(queryUtil.countSelectQueries() - afterMiss)
                 .as("SMType cache hit must produce 0 queries")
                 .isZero();
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/SoftwareModuleTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/SoftwareModuleTypeManagementCacheTest.java
@@ -29,15 +29,15 @@ class SoftwareModuleTypeManagementCacheTest extends AbstractTypeManagementCacheT
     void verifySoftwareModuleTypeCacheMissThenHit() {
         evict(JpaSoftwareModuleType.class.getSimpleName(), osType.getId());
 
-        final long afterEvict = queryUtil.countSelectQueries();
+        final long afterEvict = queryCount.countSelect();
         softwareModuleTypeManagement.get(osType.getId()); // miss
-        assertThat(queryUtil.countSelectQueries() - afterEvict)
+        assertThat(queryCount.countSelect() - afterEvict)
                 .as("SMType cache miss must produce exactly 1 query")
                 .isEqualTo(1);
 
-        final long afterMiss = queryUtil.countSelectQueries();
+        final long afterMiss = queryCount.countSelect();
         softwareModuleTypeManagement.get(osType.getId()); // hit
-        assertThat(queryUtil.countSelectQueries() - afterMiss)
+        assertThat(queryCount.countSelect() - afterMiss)
                 .as("SMType cache hit must produce 0 queries")
                 .isZero();
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementCacheTest.java
@@ -11,11 +11,8 @@ package org.eclipse.hawkbit.repository.jpa.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Set;
-
 import org.eclipse.hawkbit.repository.jpa.model.JpaTargetType;
 import org.eclipse.hawkbit.repository.model.TargetType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,17 +29,17 @@ class TargetTypeManagementCacheTest extends AbstractTypeManagementCacheTest {
         final TargetType targetType = testdataFactory.findOrCreateTargetType("cacheTargetType");
         evict(JpaTargetType.class.getSimpleName(), targetType.getId());
 
-        final long beforeMiss = readQueries();
+        final long beforeMiss = queryUtil.countSelectQueries();
         targetTypeManagement.get(targetType.getId()); // miss — hits DB
-        assertThat(readQueries() - beforeMiss)
+        assertThat(queryUtil.countSelectQueries() - beforeMiss)
                 .as("cache miss must load from DB")
                 .isPositive();
 
-        final long beforeHits = readQueries();
+        final long beforeHits = queryUtil.countSelectQueries();
         for (int i = 0; i < 5; i++) {
             targetTypeManagement.get(targetType.getId()); // all served from cache
         }
-        assertThat(readQueries() - beforeHits)
+        assertThat(queryUtil.countSelectQueries() - beforeHits)
                 .as("repeated reads must be served from cache — 0 DB queries")
                 .isZero();
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementCacheTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementCacheTest.java
@@ -29,17 +29,17 @@ class TargetTypeManagementCacheTest extends AbstractTypeManagementCacheTest {
         final TargetType targetType = testdataFactory.findOrCreateTargetType("cacheTargetType");
         evict(JpaTargetType.class.getSimpleName(), targetType.getId());
 
-        final long beforeMiss = queryUtil.countSelectQueries();
+        final long beforeMiss = queryCount.countSelect();
         targetTypeManagement.get(targetType.getId()); // miss — hits DB
-        assertThat(queryUtil.countSelectQueries() - beforeMiss)
+        assertThat(queryCount.countSelect() - beforeMiss)
                 .as("cache miss must load from DB")
                 .isPositive();
 
-        final long beforeHits = queryUtil.countSelectQueries();
+        final long beforeHits = queryCount.countSelect();
         for (int i = 0; i < 5; i++) {
             targetTypeManagement.get(targetType.getId()); // all served from cache
         }
-        assertThat(queryUtil.countSelectQueries() - beforeHits)
+        assertThat(queryCount.countSelect() - beforeHits)
                 .as("repeated reads must be served from cache — 0 DB queries")
                 .isZero();
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementTest.java
@@ -30,7 +30,7 @@ import org.eclipse.hawkbit.repository.model.Type;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
 import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
-import org.eclipse.hawkbit.repository.test.util.QueryUtil;
+import org.eclipse.hawkbit.repository.test.util.QueryCount;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -43,7 +43,7 @@ import org.springframework.context.annotation.Import;
 class TargetTypeManagementTest extends AbstractRepositoryManagementTest<TargetType, Create, Update> {
 
     @Autowired
-    private QueryUtil queryUtil;
+    private QueryCount queryCount;
 
     /**
      * Tests the successful assignment of compatible distribution set types to a target type
@@ -210,9 +210,9 @@ class TargetTypeManagementTest extends AbstractRepositoryManagementTest<TargetTy
         targetTypeManagement.assignCompatibleDistributionSetTypes(
                 targetType.getId(), Collections.singletonList(defaultDsType().getId()));
 
-        queryUtil.resetQueries();
+        queryCount.resetQueries();
         targetTypeManagement.get(targetType.getId()).getDistributionSetTypes().forEach(dst -> dst.getKey());
 
-        assertThat(queryUtil.countSelectsFromTable("sp_software_module_type")).isZero();
+        assertThat(queryCount.countSelectsFromTable("sp_software_module_type")).isZero();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/TargetTypeManagementTest.java
@@ -29,13 +29,21 @@ import org.eclipse.hawkbit.repository.model.TargetType;
 import org.eclipse.hawkbit.repository.model.Type;
 import org.eclipse.hawkbit.repository.test.matcher.Expect;
 import org.eclipse.hawkbit.repository.test.matcher.ExpectEvents;
+import org.eclipse.hawkbit.repository.test.util.QueryCountConfiguration;
+import org.eclipse.hawkbit.repository.test.util.QueryUtil;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feature: Component Tests - Repository<br/>
  * Story: Target Type Management
  */
+@Import(QueryCountConfiguration.class)
 class TargetTypeManagementTest extends AbstractRepositoryManagementTest<TargetType, Create, Update> {
+
+    @Autowired
+    private QueryUtil queryUtil;
 
     /**
      * Tests the successful assignment of compatible distribution set types to a target type
@@ -189,5 +197,22 @@ class TargetTypeManagementTest extends AbstractRepositoryManagementTest<TargetTy
                 .as("targetType with too short name should not be updated")
                 .isThrownBy(() -> targetTypeManagement.update(targetTypeUpdateEmpty));
 
+    }
+
+    /**
+     * Navigating a target type's compatible distribution set types issues no {@code sp_software_module_type} query -
+     * materialising the distribution set types does not resolve their module type entities.
+     */
+    @Test
+    void loadingCompatibleDistributionSetTypesIssuesNoSoftwareModuleTypeQuery() {
+        final TargetType targetType = targetTypeManagement.create(
+                Create.builder().name("smtype-compat").description("d").key("smtype-compat.key").build());
+        targetTypeManagement.assignCompatibleDistributionSetTypes(
+                targetType.getId(), Collections.singletonList(defaultDsType().getId()));
+
+        queryUtil.resetQueries();
+        targetTypeManagement.get(targetType.getId()).getDistributionSetTypes().forEach(dst -> dst.getKey());
+
+        assertThat(queryUtil.countSelectsFromTable("sp_software_module_type")).isZero();
     }
 }

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCount.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCount.java
@@ -19,10 +19,10 @@ import java.util.Locale;
  * <p>
  * Records at the JDBC layer (see {@link QueryCountingDataSource}) rather than through a JPA-provider profiler, so the
  * same assertions hold under both EclipseLink and Hibernate. Reset it before the measured section, then inspect the
- * recorded statements afterwards - as a count ({@link #countSelectQueries()} / {@link #countSelectsFromTable(String)})
- * or as the raw list ({@link #getAllQueries()}).
+ * recorded statements afterwards - as a count ({@link #countSelect()} / {@link #countSelectsFromTable(String)})
+ * or as the raw list ({@link #getAllStatements()}).
  */
-public class QueryUtil {
+public class QueryCount {
 
     private final List<String> statements = Collections.synchronizedList(new ArrayList<>());
 
@@ -32,9 +32,9 @@ public class QueryUtil {
     }
 
     /** Number of executed {@code SELECT} statements since the last {@link #resetQueries()}. */
-    public long countSelectQueries() {
+    public long countSelect() {
         synchronized (statements) {
-            return statements.stream().filter(QueryUtil::isSelect).count();
+            return statements.stream().filter(QueryCount::isSelect).count();
         }
     }
 
@@ -51,7 +51,7 @@ public class QueryUtil {
     }
 
     /** Immutable snapshot of the recorded statements - useful for debugging an unexpected count. */
-    public List<String> getAllQueries() {
+    public List<String> getAllStatements() {
         synchronized (statements) {
             return List.copyOf(statements);
         }

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountConfiguration.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * Wraps the application {@link DataSource} with a {@link QueryCountingDataSource} and exposes the shared
- * {@link QueryUtil}. {@code @Import} it only on the tests that need SQL inspection (opt-in), then autowire the
+ * {@link QueryCount}. {@code @Import} it only on the tests that need SQL inspection (opt-in), then autowire the
  * {@code queryUtil} bean:
  *
  * <pre>{@code
@@ -33,12 +33,12 @@ import org.springframework.context.annotation.Configuration;
 public class QueryCountConfiguration {
 
     @Bean
-    public QueryUtil queryCount() {
-        return new QueryUtil();
+    public QueryCount queryCount() {
+        return new QueryCount();
     }
 
     @Bean
-    static BeanPostProcessor queryCountingDataSourcePostProcessor(final ObjectProvider<QueryUtil> queryCount) {
+    static BeanPostProcessor queryCountingDataSourcePostProcessor(final ObjectProvider<QueryCount> queryCount) {
         return new BeanPostProcessor() {
 
             @Override

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountConfiguration.java
@@ -17,28 +17,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Opt-in test configuration that wraps the application {@link DataSource} with a {@link QueryCountingDataSource} and
- * exposes the shared {@link QueryCount}. Import it on a test that needs to assert how many SQL statements reach the DB:
+ * Wraps the application {@link DataSource} with a {@link QueryCountingDataSource} and exposes the shared
+ * {@link QueryUtil}. {@code @Import} it only on the tests that need SQL inspection (opt-in), then autowire the
+ * {@code queryUtil} bean:
  *
  * <pre>{@code
- * @Import(QueryCountConfiguration.class)
- * class MyPerfTest extends AbstractJpaIntegrationTest {
- *     @Autowired QueryCount queryCount;
- * }
+ * queryUtil.resetQueries();
+ * ... code under test ...
+ * assertThat(queryUtil.countSelectsFromTable("sp_software_module_type")).isZero();
  * }</pre>
  *
- * Provider-agnostic - counting happens at the JDBC layer, so it behaves identically under EclipseLink and Hibernate.
+ * Provider-agnostic - recording happens at the JDBC layer, so it behaves identically under EclipseLink and Hibernate.
  */
 @Configuration
 public class QueryCountConfiguration {
 
     @Bean
-    public QueryCount queryCount() {
-        return new QueryCount();
+    public QueryUtil queryCount() {
+        return new QueryUtil();
     }
 
     @Bean
-    static BeanPostProcessor queryCountingDataSourcePostProcessor(final ObjectProvider<QueryCount> queryCount) {
+    static BeanPostProcessor queryCountingDataSourcePostProcessor(final ObjectProvider<QueryUtil> queryCount) {
         return new BeanPostProcessor() {
 
             @Override

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountingDataSource.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountingDataSource.java
@@ -24,7 +24,7 @@ import javax.sql.DataSource;
 import org.springframework.jdbc.datasource.DelegatingDataSource;
 
 /**
- * A {@link DataSource} wrapper that records every SQL statement executed through it into a {@link QueryCount}.
+ * A {@link DataSource} wrapper that records every SQL statement executed through it into a {@link QueryUtil}.
  * <p>
  * Works at the JDBC layer via dynamic proxies on {@link Connection} and {@link Statement}, so it is completely
  * JPA-provider agnostic (both EclipseLink and Hibernate issue their SQL through this data source). The SQL of a
@@ -33,11 +33,11 @@ import org.springframework.jdbc.datasource.DelegatingDataSource;
  */
 public class QueryCountingDataSource extends DelegatingDataSource {
 
-    private final QueryCount queryCount;
+    private final QueryUtil queryUtil;
 
-    public QueryCountingDataSource(final DataSource targetDataSource, final QueryCount queryCount) {
+    public QueryCountingDataSource(final DataSource targetDataSource, final QueryUtil queryUtil) {
         super(targetDataSource);
-        this.queryCount = queryCount;
+        this.queryUtil = queryUtil;
     }
 
     @Override
@@ -70,17 +70,16 @@ public class QueryCountingDataSource extends DelegatingDataSource {
                 // prepareStatement/prepareCall carry the SQL as first arg; createStatement has none (SQL at execute time)
                 final String preparedSql = (args != null && args.length > 0 && args[0] instanceof String sql) ? sql : null;
                 return Proxy.newProxyInstance(getClass().getClassLoader(),
-                        new Class<?>[] { statementInterface(method) }, new StatementHandler(statement, preparedSql));
+                        new Class<?>[] { statementInterface(statement) }, new StatementHandler(statement, preparedSql));
             }
             return result;
         }
 
-        private Class<?> statementInterface(final Method factoryMethod) {
-            final String name = factoryMethod.getName();
-            if (name.equals("prepareCall")) {
+        private Class<?> statementInterface(final Statement statement) {
+            if (statement instanceof CallableStatement) {
                 return CallableStatement.class;
             }
-            return name.equals("prepareStatement") ? PreparedStatement.class : Statement.class;
+            return statement instanceof PreparedStatement ? PreparedStatement.class : Statement.class;
         }
     }
 
@@ -99,7 +98,7 @@ public class QueryCountingDataSource extends DelegatingDataSource {
             if (method.getName().startsWith("execute")) {
                 // plain Statement passes the SQL as first arg; PreparedStatement uses the SQL captured at prepare time
                 final String sql = (args != null && args.length > 0 && args[0] instanceof String s) ? s : preparedSql;
-                queryCount.record(sql);
+                queryUtil.record(sql);
             }
             return invokeTarget(statement, method, args);
         }

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountingDataSource.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryCountingDataSource.java
@@ -24,7 +24,7 @@ import javax.sql.DataSource;
 import org.springframework.jdbc.datasource.DelegatingDataSource;
 
 /**
- * A {@link DataSource} wrapper that records every SQL statement executed through it into a {@link QueryUtil}.
+ * A {@link DataSource} wrapper that records every SQL statement executed through it into a {@link QueryCount}.
  * <p>
  * Works at the JDBC layer via dynamic proxies on {@link Connection} and {@link Statement}, so it is completely
  * JPA-provider agnostic (both EclipseLink and Hibernate issue their SQL through this data source). The SQL of a
@@ -33,11 +33,11 @@ import org.springframework.jdbc.datasource.DelegatingDataSource;
  */
 public class QueryCountingDataSource extends DelegatingDataSource {
 
-    private final QueryUtil queryUtil;
+    private final QueryCount queryCount;
 
-    public QueryCountingDataSource(final DataSource targetDataSource, final QueryUtil queryUtil) {
+    public QueryCountingDataSource(final DataSource targetDataSource, final QueryCount queryCount) {
         super(targetDataSource);
-        this.queryUtil = queryUtil;
+        this.queryCount = queryCount;
     }
 
     @Override
@@ -98,7 +98,7 @@ public class QueryCountingDataSource extends DelegatingDataSource {
             if (method.getName().startsWith("execute")) {
                 // plain Statement passes the SQL as first arg; PreparedStatement uses the SQL captured at prepare time
                 final String sql = (args != null && args.length > 0 && args[0] instanceof String s) ? s : preparedSql;
-                queryUtil.record(sql);
+                queryCount.record(sql);
             }
             return invokeTarget(statement, method, args);
         }

--- a/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryUtil.java
+++ b/hawkbit-repository/hawkbit-repository-test/src/main/java/org/eclipse/hawkbit/repository/test/util/QueryUtil.java
@@ -15,46 +15,43 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * Provider-agnostic JDBC statement recorder used by performance/caching tests to count SQL actually sent to the DB.
+ * Provider-agnostic JDBC statement recorder used by performance/caching tests to inspect the SQL actually sent to the DB.
  * <p>
- * Counts at the JDBC layer (see {@link QueryCountingDataSource}) rather than through a JPA-provider profiler, so the
- * same assertions hold under both EclipseLink and Hibernate. Reset it before the measured section and query the counts
- * afterwards.
+ * Records at the JDBC layer (see {@link QueryCountingDataSource}) rather than through a JPA-provider profiler, so the
+ * same assertions hold under both EclipseLink and Hibernate. Reset it before the measured section, then inspect the
+ * recorded statements afterwards - as a count ({@link #countSelectQueries()} / {@link #countSelectsFromTable(String)})
+ * or as the raw list ({@link #getAllQueries()}).
  */
-public class QueryCount {
+public class QueryUtil {
 
     private final List<String> statements = Collections.synchronizedList(new ArrayList<>());
 
     /** Clears all recorded statements - call right before the section under measurement. */
-    public void reset() {
+    public void resetQueries() {
         statements.clear();
     }
 
-    /** Total number of executed statements recorded since the last {@link #reset()}. */
-    public long total() {
-        return statements.size();
-    }
-
-    /** Number of executed {@code SELECT} statements since the last {@link #reset()}. */
-    public long selects() {
+    /** Number of executed {@code SELECT} statements since the last {@link #resetQueries()}. */
+    public long countSelectQueries() {
         synchronized (statements) {
-            return statements.stream().filter(QueryCount::isSelect).count();
+            return statements.stream().filter(QueryUtil::isSelect).count();
         }
     }
 
     /**
-     * Number of executed statements whose SQL contains the given (case-insensitive) fragment - typically a table name
-     * such as {@code sp_software_module_type}.
+     * Number of statements (since the last {@link #resetQueries()}) that read FROM the given table - i.e. contain
+     * {@code "from <table>"}. Distinguishes e.g. a {@code sp_software_module_type} by-id load from a query that merely
+     * has a {@code software_module_type} column.
      */
-    public long matching(final String sqlFragment) {
-        final String needle = sqlFragment.toLowerCase(Locale.ROOT);
+    public long countSelectsFromTable(final String table) {
+        final String needle = "from " + table.toLowerCase(Locale.ROOT);
         synchronized (statements) {
             return statements.stream().filter(s -> s != null && s.toLowerCase(Locale.ROOT).contains(needle)).count();
         }
     }
 
     /** Immutable snapshot of the recorded statements - useful for debugging an unexpected count. */
-    public List<String> statements() {
+    public List<String> getAllQueries() {
         synchronized (statements) {
             return List.copyOf(statements);
         }


### PR DESCRIPTION
- exposed getSmTypeId to read the smtype id directly from the CompositeKey rather then loading the smType
- exposed JpaDistribtuionSetType getMandatoryModuleTypeIds() and getOptionalModuleTypeIds() again to get the ids from the element composite key rather then loading the sm types
- Improved the QueryUtil for sql readings among tests
- used QueryUtil to test the smType lazy loading (and actually not loading whenever ids are needed)