### PR TITLE
Add optional externalRef to distribution set assignment requests

### DIFF
--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtTargetAssignmentRequestBody.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/distributionset/MgmtTargetAssignmentRequestBody.java
@@ -44,6 +44,9 @@ public class MgmtTargetAssignmentRequestBody {
             "an action. Confirmation is required per default")
     private Boolean confirmationRequired;
 
+    @Schema(description = "If set, the external reference is applied to the resulting action", example = "extRef1234")
+    private String externalRef;
+
     /**
      * JsonCreator Constructor
      *

--- a/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtDistributionSetAssignment.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-api/src/main/java/org/eclipse/hawkbit/mgmt/json/model/target/MgmtDistributionSetAssignment.java
@@ -42,6 +42,9 @@ public class MgmtDistributionSetAssignment extends MgmtId {
     @Schema(description = "Separation of download and install by defining a maintenance window for the installation")
     private MgmtMaintenanceWindowRequestBody maintenanceWindow;
 
+    @Schema(description = "If set, the external reference is applied to the resulting action", example = "extRef1234")
+    private String externalRef;
+
     /**
      * Constructor
      *

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtDeploymentRequestMapper.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/mapper/MgmtDeploymentRequestMapper.java
@@ -35,7 +35,7 @@ public final class MgmtDeploymentRequestMapper {
     public static DeploymentRequestBuilder createAssignmentRequestBuilder(
             final MgmtDistributionSetAssignment dsAssignment, final String targetId) {
         return createAssignmentRequestBuilder(targetId, dsAssignment.getId(), dsAssignment.getType(),
-                dsAssignment.getForcetime(), dsAssignment.getWeight(), dsAssignment.getMaintenanceWindow());
+                dsAssignment.getForcetime(), dsAssignment.getWeight(), dsAssignment.getMaintenanceWindow(), dsAssignment.getExternalRef());
     }
 
     /**
@@ -48,14 +48,17 @@ public final class MgmtDeploymentRequestMapper {
     public static DeploymentRequestBuilder createAssignmentRequestBuilder(
             final MgmtTargetAssignmentRequestBody targetAssignment, final Long dsId) {
         return createAssignmentRequestBuilder(targetAssignment.getId(), dsId, targetAssignment.getType(),
-                targetAssignment.getForcetime(), targetAssignment.getWeight(), targetAssignment.getMaintenanceWindow());
+                targetAssignment.getForcetime(), targetAssignment.getWeight(), targetAssignment.getMaintenanceWindow(),
+                targetAssignment.getExternalRef());
     }
 
+    @SuppressWarnings("java:S107")
     private static DeploymentRequestBuilder createAssignmentRequestBuilder(final String targetId, final Long dsId,
             final MgmtActionType type, final long forcetime, final Integer weight,
-            final MgmtMaintenanceWindowRequestBody maintenanceWindow) {
+            final MgmtMaintenanceWindowRequestBody maintenanceWindow, final String externalRef) {
         final DeploymentRequestBuilder request = DeploymentRequest.builder(targetId, dsId)
-                .actionType(MgmtRestModelMapper.convertActionType(type)).forceTime(forcetime).weight(weight);
+                .actionType(MgmtRestModelMapper.convertActionType(type)).forceTime(forcetime).weight(weight)
+                .externalRef(externalRef);
         if (maintenanceWindow != null) {
             final String cronSchedule = maintenanceWindow.getSchedule();
             final String duration = maintenanceWindow.getDuration();

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtDistributionSetResourceTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.jayway.jsonpath.JsonPath;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,8 +38,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import com.jayway.jsonpath.JsonPath;
 import org.eclipse.hawkbit.auth.SpRole;
 import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.mgmt.json.model.MgmtId;
@@ -1719,6 +1718,7 @@ class MgmtDistributionSetResourceTest extends AbstractManagementApiIntegrationTe
 
     /**
      * An assignment request containing a weight is only accepted when weight is valide and multi assignment is on.
+     * The assignment also carries an externalRef that is expected to be persisted on the resulting action.
      */
     @Test
     void weightValidation() throws Exception {
@@ -1726,21 +1726,23 @@ class MgmtDistributionSetResourceTest extends AbstractManagementApiIntegrationTe
         final Long dsId1 = testdataFactory.createDistributionSet().getId();
         final Long dsId2 = testdataFactory.createDistributionSet().getId();
         final int weight = 78;
+        final String externalRef = "extRef-" + weight;
 
-        final JSONArray bodyValide = new JSONArray().put(getAssignmentObject(targetId, MgmtActionType.FORCED, weight));
-        final JSONArray bodyInvalide = new JSONArray()
+        final JSONArray bodyValid = new JSONArray()
+                .put(getAssignmentObject(targetId, MgmtActionType.FORCED, weight).put("externalRef", externalRef));
+        final JSONArray bodyInvalid = new JSONArray()
                 .put(getAssignmentObject(targetId, MgmtActionType.FORCED, Action.WEIGHT_MIN - 1));
 
-        mvc.perform(post("/rest/v1/distributionsets/{ds}/assignedTargets", dsId1).content(bodyValide.toString())
+        mvc.perform(post("/rest/v1/distributionsets/{ds}/assignedTargets", dsId1).content(bodyValid.toString())
                         .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
-        mvc.perform(post("/rest/v1/distributionsets/{ds}/assignedTargets", dsId2).content(bodyInvalide.toString())
+        mvc.perform(post("/rest/v1/distributionsets/{ds}/assignedTargets", dsId2).content(bodyInvalid.toString())
                         .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode", equalTo("hawkbit.server.error.repo.constraintViolation")));
-        mvc.perform(post("/rest/v1/distributionsets/{ds}/assignedTargets", dsId2).content(bodyValide.toString())
+        mvc.perform(post("/rest/v1/distributionsets/{ds}/assignedTargets", dsId2).content(bodyValid.toString())
                         .contentType(APPLICATION_JSON))
                 .andDo(MockMvcResultPrinter.print())
                 .andExpect(status().isOk());
@@ -1748,6 +1750,8 @@ class MgmtDistributionSetResourceTest extends AbstractManagementApiIntegrationTe
         final List<Action> actions = deploymentManagement.findActionsAll(PAGE).get().toList();
         assertThat(actions).size().isEqualTo(2);
         assertThat(actions.get(0).getWeight()).get().isEqualTo(weight);
+        assertThat(actions.get(0).getExternalRef()).isEqualTo(externalRef);
+        assertThat(actions.get(1).getExternalRef()).isEqualTo(externalRef);
     }
 
     /**

--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/test/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtTargetResourceTest.java
@@ -32,6 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.jayway.jsonpath.JsonPath;
+import jakarta.validation.ConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -42,10 +44,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import jakarta.validation.ConstraintViolationException;
-
-import com.jayway.jsonpath.JsonPath;
 import org.eclipse.hawkbit.auth.SpPermission;
 import org.eclipse.hawkbit.exception.SpServerError;
 import org.eclipse.hawkbit.mgmt.json.model.action.MgmtActionConfirmationRequestBodyPut;
@@ -2211,14 +2209,16 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
 
     /**
      * An assignment request containing a weight is only accepted when weight is valid and multi assignment is on.
+     * The assignment also carries an externalRef that is expected to be persisted on the resulting action.
      */
     @Test
     void weightValidation() throws Exception {
         final String targetId = testdataFactory.createTarget().getControllerId();
         final Long dsId = testdataFactory.createDistributionSet().getId();
         final int weight = 98;
+        final String externalRef = "extRef-" + weight;
 
-        final JSONObject bodyValid = getAssignmentObject(dsId, MgmtActionType.FORCED, weight);
+        final JSONObject bodyValid = getAssignmentObject(dsId, MgmtActionType.FORCED, weight).put("externalRef", externalRef);
         final JSONObject bodyInvalid = getAssignmentObject(dsId, MgmtActionType.FORCED, Action.WEIGHT_MIN - 1);
 
         mvc.perform(post("/rest/v1/targets/{targetId}/assignedDS", targetId).content(bodyInvalid.toString()).contentType(APPLICATION_JSON))
@@ -2232,6 +2232,7 @@ class MgmtTargetResourceTest extends AbstractManagementApiIntegrationTest {
         final List<Action> actions = deploymentManagement.findActionsAll(PAGE).get().toList();
         assertThat(actions).size().isEqualTo(1);
         assertThat(actions.get(0).getWeight()).get().isEqualTo(weight);
+        assertThat(actions.get(0).getExternalRef()).isEqualTo(externalRef);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DeploymentRequest.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/DeploymentRequest.java
@@ -47,17 +47,18 @@ public class DeploymentRequest {
      *         {@link org.eclipse.hawkbit.repository.model.Action.Status#RUNNING} state. Otherwise, the confirmation flow will be triggered
      *         and the {@link Action} will stay in the {@link org.eclipse.hawkbit.repository.model.Action.Status#WAIT_FOR_CONFIRMATION}
      *         state until the confirmation is given. (Only considered with CONFIRMATION_FLOW active via tenant configuration)
+     * @param externalRef (optional) external reference that is set on the resulting {@link Action}.
      * @throws InvalidMaintenanceScheduleException if the parameters do not define a valid maintenance schedule.
      */
     @SuppressWarnings("java:S107")
     public DeploymentRequest(
             final String controllerId, final Long distributionSetId, final ActionType actionType, final long forceTime, final Integer weight,
             final String maintenanceSchedule, final String maintenanceWindowDuration, final String maintenanceWindowTimeZone,
-            final boolean confirmationRequired) {
+            final boolean confirmationRequired, final String externalRef) {
         this.targetWithActionType = new TargetWithActionType(
                 controllerId, actionType, forceTime, weight,
                 maintenanceSchedule, maintenanceWindowDuration, maintenanceWindowTimeZone,
-                confirmationRequired);
+                confirmationRequired, externalRef);
         this.distributionSetId = distributionSetId;
     }
 
@@ -87,6 +88,8 @@ public class DeploymentRequest {
         private String maintenanceWindowTimeZone;
         @Setter
         private boolean confirmationRequired;
+        @Setter
+        private String externalRef;
 
         /**
          * Create a builder for a target distribution set assignment with the mandatory fields
@@ -119,7 +122,7 @@ public class DeploymentRequest {
 
         public DeploymentRequest build() {
             return new DeploymentRequest(controllerId, distributionSetId, actionType, forceTime, weight,
-                    maintenanceSchedule, maintenanceWindowDuration, maintenanceWindowTimeZone, confirmationRequired);
+                    maintenanceSchedule, maintenanceWindowDuration, maintenanceWindowTimeZone, confirmationRequired, externalRef);
         }
     }
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TargetWithActionType.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/TargetWithActionType.java
@@ -32,6 +32,7 @@ public class TargetWithActionType {
     private final String maintenanceSchedule;
     private final String maintenanceWindowDuration;
     private final String maintenanceWindowTimeZone;
+    private final String externalRef;
 
     /**
      * Constructor that also accepts maintenance schedule parameters and checks for validity of the specified maintenance schedule.
@@ -45,13 +46,15 @@ public class TargetWithActionType {
      * @param maintenanceWindowDuration in HH:mm:ss format specifying the duration of a maintenance window, for example 00:30:00 for 30 minutes
      * @param maintenanceWindowTimeZone is the time zone specified as +/-hh:mm offset from UTC, for example +02:00 for CET summer time
      *         and +00:00 for UTC. The start time of a maintenance window calculated based on the cron expression is relative to this time zone.
+     * @param confirmationRequired whether confirmation is required for the resulting {@link Action}.
+     * @param externalRef (optional) external reference that is set on the resulting {@link Action}.
      * @throws InvalidMaintenanceScheduleException if the parameters do not define a valid maintenance schedule.
      */
     @SuppressWarnings("java:S107")
     public TargetWithActionType(
             final String controllerId, final ActionType actionType, final long forceTime, final Integer weight,
             final String maintenanceSchedule, final String maintenanceWindowDuration, final String maintenanceWindowTimeZone,
-            final boolean confirmationRequired) {
+            final boolean confirmationRequired, final String externalRef) {
         this.controllerId = controllerId;
         this.actionType = actionType != null ? actionType : ActionType.FORCED;
         this.forceTime = actionType == ActionType.TIMEFORCED ? forceTime : RepositoryModelConstants.NO_FORCE_TIME;
@@ -62,5 +65,6 @@ public class TargetWithActionType {
         this.maintenanceWindowTimeZone = maintenanceWindowTimeZone;
 
         this.confirmationRequired = confirmationRequired;
+        this.externalRef = externalRef;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/AbstractDsAssignmentStrategy.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/management/AbstractDsAssignmentStrategy.java
@@ -11,14 +11,12 @@ package org.eclipse.hawkbit.repository.jpa.management;
 
 import static org.eclipse.hawkbit.repository.jpa.executor.AfterTransactionCommitExecutor.afterCommit;
 
+import jakarta.persistence.criteria.JoinType;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
-
-import jakarta.persistence.criteria.JoinType;
-
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.hawkbit.context.AccessContext;
 import org.eclipse.hawkbit.repository.RepositoryConstants;
@@ -99,6 +97,9 @@ public abstract class AbstractDsAssignmentStrategy {
             actionForTarget.setMaintenanceWindowSchedule(targetWithActionType.getMaintenanceSchedule());
             actionForTarget.setMaintenanceWindowDuration(targetWithActionType.getMaintenanceWindowDuration());
             actionForTarget.setMaintenanceWindowTimeZone(targetWithActionType.getMaintenanceWindowTimeZone());
+            if (StringUtils.hasText(targetWithActionType.getExternalRef())) {
+                actionForTarget.setExternalRef(targetWithActionType.getExternalRef());
+            }
             actionForTarget.setInitiatedBy(AccessContext.actor());
             return actionForTarget;
         }).orElseGet(() -> {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/acm/DeploymentManagementTest.java
@@ -40,7 +40,7 @@ class DeploymentManagementTest extends AbstractAccessControllerManagementTest {
                         READ_DISTRIBUTION_SET),
                 () -> assertThat(deploymentManagement.assignDistributionSets(List.of(new DeploymentRequest(
                                 target1Type1.getControllerId(), ds1Type1.getId(), Action.ActionType.FORCED, 0,
-                                null, null, null, null, false)), null)
+                                null, null, null, null, false, null)), null)
                         .get(0).getAssignedEntity().stream().map(Action::getTarget)
                         .map(Target::getId))
                         .hasSize(1)
@@ -52,7 +52,7 @@ class DeploymentManagementTest extends AbstractAccessControllerManagementTest {
                         READ_DISTRIBUTION_SET),
                 () -> assertThat(deploymentManagement.assignDistributionSets(List.of(new DeploymentRequest(
                         target1Type1.getControllerId(), ds1Type1.getId(), Action.ActionType.FORCED, 0,
-                        null, null, null, null, false)), null)).isEmpty());
+                        null, null, null, null, false, null)), null)).isEmpty());
     }
 
     @Test

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DeploymentManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/management/DeploymentManagementTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.hawkbit.repository.model.Action.Status.WAIT_FOR_CONFIR
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,9 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import jakarta.validation.ConstraintViolationException;
-
 import lombok.Getter;
 import org.assertj.core.api.Assertions;
 import org.eclipse.hawkbit.context.AccessContext;
@@ -1594,7 +1592,7 @@ class DeploymentManagementTest extends AbstractJpaIntegrationTest {
         final List<DeploymentRequest> deploymentRequests = new ArrayList<>();
         for (final String controllerId : targetIds) {
             deploymentRequests.add(new DeploymentRequest(controllerId, distributionSet.getId(), ActionType.FORCED, 0,
-                    null, null, null, null, confirmationRequired));
+                    null, null, null, null, confirmationRequired, null));
         }
         return deploymentManagement.assignDistributionSets(deploymentRequests, null);
     }


### PR DESCRIPTION
MgmtDistributionSetAssignment and MgmtTargetAssignmentRequestBody were extended with an optional externalRef field. The value is propagated through TargetWithActionType/DeploymentRequest down to JpaAction creation in AbstractDsAssignmentStrategy, where it is set if provided. Instead of adding new tests, the existing weightValidation tests in MgmtDistributionSetResourceTest and MgmtTargetResourceTest were extended to verify that the field is persisted on the resulting action. Two direct DeploymentRequest constructor calls in JPA tests were adjusted to the new signature.