### PR TITLE
fix: add OAuth2 to OpenAPI global security requirement

### DIFF
--- a/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtOpenApiConfiguration.java
+++ b/hawkbit-mgmt/hawkbit-mgmt-resource/src/main/java/org/eclipse/hawkbit/mgmt/rest/resource/MgmtOpenApiConfiguration.java
@@ -74,7 +74,7 @@ public class MgmtOpenApiConfiguration {
                     .bearerFormat("JWT")
                     .scheme("bearer"));
             if (!tokenUrl.isBlank()) {
-                securityRequirement.addList(BEARER_AUTH_SEC_SCHEME_NAME);
+                securityRequirement.addList(OAUTH2_AUTH_SEC_SCHEME_NAME);
                 securitySchemeMap.put(OAUTH2_AUTH_SEC_SCHEME_NAME, new SecurityScheme()
                         .description(OAUTH2_AUTH_SEC_SCHEME_NAME + DESCRIPTION_SUFFIX)
                         .type(SecurityScheme.Type.OAUTH2)


### PR DESCRIPTION
securityRequirement.addList was calling BEARER_AUTH_SEC_SCHEME_NAME instead of OAUTH2_AUTH_SEC_SCHEME_NAME inside the tokenUrl block, so the OAuth2 scheme appeared in securitySchemes but not in the top-level security requirement — making it invisible in Swagger UI.

Do I need to create a PR to backport the fix to 1.1 branch ? 